### PR TITLE
ユーザの本棚取得API#37

### DIFF
--- a/app/Book.php
+++ b/app/Book.php
@@ -6,7 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Book extends Model
 {
+
+    /**
+     * リレーション定義
+     */
     public function genre(){
         return $this->belongsTo(Genre::class);
+    }
+
+    public function users(){
+        return $this->belongsToMany(User::class);
     }
 }

--- a/app/Book.php
+++ b/app/Book.php
@@ -6,5 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Book extends Model
 {
-    //
+    public function genre(){
+        return $this->belongsTo(Genre::class);
+    }
 }

--- a/app/Genre.php
+++ b/app/Genre.php
@@ -6,5 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Genre extends Model
 {
-    //
+    public function books(){
+        return $this->hasMany(Book::class);
+    }
 }

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\UserBook;
+use Illuminate\Http\Request;
+
+class UserBookController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\UserBook  $userBook
+     * @return \Illuminate\Http\Response
+     */
+    public function show(UserBook $userBook)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\UserBook  $userBook
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(UserBook $userBook)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\UserBook  $userBook
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, UserBook $userBook)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\UserBook  $userBook
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(UserBook $userBook)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -19,10 +19,10 @@ class UserBookController extends Controller
     public function index($userId)
     {
 
-        $userbooks = User::with(array('books'=>function($q){
+        $userbooks = User::with(['books'=>function($q){
                         $q->select('books.id','books.name', 'books.cover', 'books.author', 'books.genre_id');
-                     }))
-                     ->select(['users.id', 'users.name', 'users.avatar', 'users.description', 'users.role_id'])
+                     }])
+                     ->select('users.id', 'users.name', 'users.avatar', 'users.description', 'users.role_id')
                      ->find($userId);
                     
         

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -18,16 +18,12 @@ class UserBookController extends Controller
      */
     public function index($userId)
     {
-        // $userbooks = UserBook::where('user_id', '=', $userId)
-        //             ->join('books', 'user_book.book_id', '=', 'books.id')
-        //             ->select()
-        //             ->get();
 
         $userbooks = User::with(array('books'=>function($q){
                         $q->select('books.id','books.name', 'books.cover', 'books.author', 'books.genre_id');
-                    }))
-                    ->select(['users.id', 'users.name', 'users.avatar', 'users.description', 'users.role_id'])
-                    ->find($userId);
+                     }))
+                     ->select(['users.id', 'users.name', 'users.avatar', 'users.description', 'users.role_id'])
+                     ->find($userId);
                     
         
         return response()->json(

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\UserBook;
+use App\User;
+use App\Book;
 use Illuminate\Http\Request;
 
 class UserBookController extends Controller
@@ -14,14 +16,20 @@ class UserBookController extends Controller
      * @param string $userId
      * @return \Illuminate\Http\Response
      */
-    public function index(Request $request, $userId)
+    public function index($userId)
     {
-        $userbooks = UserBook::find($userId)
-                    ->with('users')
-                    ->with('books')
-                    ->with('reviews')
-                    ->get();
+        // $userbooks = UserBook::where('user_id', '=', $userId)
+        //             ->join('books', 'user_book.book_id', '=', 'books.id')
+        //             ->select()
+        //             ->get();
 
+        $userbooks = User::with(array('books'=>function($q){
+                        $q->select('books.id','books.name', 'books.cover', 'books.author', 'books.genre_id');
+                    }))
+                    ->select(['users.id', 'users.name', 'users.avatar', 'users.description', 'users.role_id'])
+                    ->find($userId);
+                    
+        
         return response()->json(
             $userbooks,
             200,

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -10,11 +10,24 @@ class UserBookController extends Controller
     /**
      * Display a listing of the resource.
      *
+     * @param Request $request
+     * @param string $userId
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request, $userId)
     {
-        //
+        $userbooks = UserBook::find($userId)
+                    ->with('users')
+                    ->with('books')
+                    ->with('reviews')
+                    ->get();
+
+        return response()->json(
+            $userbooks,
+            200,
+            [],
+            JSON_UNESCAPED_UNICODE
+        );
     }
 
     /**

--- a/app/Review.php
+++ b/app/Review.php
@@ -12,4 +12,8 @@ class Review extends Model
     public function user(){
         return $this->belongsTo(User::class);
     }
+
+    public function userbook(){
+        return $this->belongsTo(UserBook::class);
+    }
 }

--- a/app/Review.php
+++ b/app/Review.php
@@ -13,7 +13,7 @@ class Review extends Model
         return $this->belongsTo(User::class);
     }
 
-    public function userbook(){
+    public function userBook(){
         return $this->belongsTo(UserBook::class);
     }
 }

--- a/app/Review.php
+++ b/app/Review.php
@@ -6,5 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class Review extends Model
 {
-    //
+    /**
+     *リレーション定義
+     */
+    public function user(){
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -34,4 +34,8 @@ class User extends Authenticatable
     public function books(){
         return $this->belongsToMany(Book::class);
     }
+
+    public function reviews(){
+        return $this->hasMany(Review::class);
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -32,7 +32,8 @@ class User extends Authenticatable
      * リレーション定義
      */
     public function books(){
-        return $this->belongsToMany(Book::class);
+        return $this->belongsToMany(Book::class)
+                    ->withPivot('id');
     }
 
     public function reviews(){

--- a/app/User.php
+++ b/app/User.php
@@ -33,7 +33,7 @@ class User extends Authenticatable
      */
     public function books(){
         return $this->belongsToMany(Book::class)
-                    ->withPivot('id');
+                    ->withPivot('id', 'created_at', 'updated_at');
     }
 
     public function reviews(){

--- a/app/User.php
+++ b/app/User.php
@@ -27,4 +27,11 @@ class User extends Authenticatable
     protected $hidden = [
         'password', 'remember_token',
     ];
+
+    /**
+     * リレーション定義
+     */
+    public function books(){
+        return $this->belongsToMany(Book::class);
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -33,7 +33,8 @@ class User extends Authenticatable
      */
     public function books(){
         return $this->belongsToMany(Book::class)
-                    ->withPivot('id', 'created_at', 'updated_at');
+                    ->withPivot('id')
+                    ->withTimestamps();
     }
 
     public function reviews(){

--- a/app/UserBook.php
+++ b/app/UserBook.php
@@ -7,4 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 class UserBook extends Model
 {
     protected $table = 'user_book';
+
+    /**
+     * リレーション定義
+     */
+    public function review(){
+        return $this->hasOne(Review::class);
+    }
 }

--- a/app/UserBook.php
+++ b/app/UserBook.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class UserBook extends Model
 {
-    protected $table = 'user_book';
+    protected $table = 'book_user';
 
     /**
      * リレーション定義

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "type": "project",
     "require": {
         "php": "^7.1.3",
+        "doctrine/dbal": "^2.8",
         "fideloper/proxy": "^4.0",
         "laravel/framework": "5.7.*",
         "laravel/tinker": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "66ca7343889332c2b8ecca11c251430c",
+    "content-hash": "242b49921143dee4868efbf0b55f9d7a",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -38,6 +38,234 @@
             ],
             "description": "implementation of xdg base directory specification for php",
             "time": "2014-10-24T07:27:01+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "reference": "d768d58baee9a4862ca783840eca1b9add7a7f57",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "doctrine/coding-standard": "^4.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2018-08-21T18:01:43+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "5140a64c08b4b607b9bedaae0cedd26f04a0e621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/5140a64c08b4b607b9bedaae0cedd26f04a0e621",
+                "reference": "5140a64c08b4b607b9bedaae0cedd26f04a0e621",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "^1.0",
+                "doctrine/event-manager": "^1.0",
+                "ext-pdo": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^4.0",
+                "jetbrains/phpstorm-stubs": "^2018.1.2",
+                "phpstan/phpstan": "^0.10.1",
+                "phpunit/phpunit": "^7.1.2",
+                "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                "symfony/console": "^2.0.5|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.4.5|^4.0.5"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev",
+                    "dev-develop": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2018-07-13T03:16:35+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "reference": "a520bc093a0170feeb6b14e9d83f3a14452e64b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^4.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Doctrine Event Manager component",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "eventdispatcher",
+                "eventmanager"
+            ],
+            "time": "2018-06-11T11:59:03+00:00"
         },
         {
             "name": "doctrine/inflector",

--- a/database/migrations/2018_11_02_143901_create_user_books_table.php
+++ b/database/migrations/2018_11_02_143901_create_user_books_table.php
@@ -13,7 +13,7 @@ class CreateUserBooksTable extends Migration
      */
     public function up()
     {
-        Schema::create('user_book', function (Blueprint $table) {
+        Schema::create('book_user', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('user_id');
             $table->unsignedInteger('book_id');

--- a/database/seeds/UserBooksTableSeeder.php
+++ b/database/seeds/UserBooksTableSeeder.php
@@ -12,7 +12,7 @@ class UserBooksTableSeeder extends Seeder
     public function run()
     {
         // HACK: BooksTableSeederで10個のBookが生成されていることを前提としている
-        DB::table('user_book')->insert([
+        DB::table('book_user')->insert([
             [
                 'user_id' => 1,
                 'book_id' => 1,

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,3 +29,9 @@ Route::get('/users', function (Request $request) {
  */
 Route::get('books', 'BookController@index');
 Route::get('books/{book}', 'BookController@show');
+
+/**
+ *  Resource: UserBook
+ * 
+ */
+Route::get('users/{userId}/user_books','UserBookController@index');


### PR DESCRIPTION
connect to #37 

# 概要
ユーザの本棚相当の書籍を取得するAPI実装

# 主な変更点
- ルート定義
- UserBookコントローラの作成とindexアクションの実装
- 中間テーブル(user_book)の規約に準じた名称修正
- モデルのリレーション定義（関連しているところだけ）
- Seeder実行の際に不足していたモジュールの追加（doctrine/dbal）

# レスポンス例
![default](https://user-images.githubusercontent.com/29668738/48320802-c0c22d00-e660-11e8-8034-c5247d5cdddc.PNG)

