### PR TITLE
ジャンル詳細のAPI実装#40

### DIFF
--- a/app/Http/Controllers/GenreController.php
+++ b/app/Http/Controllers/GenreController.php
@@ -24,4 +24,25 @@ class GenreController extends Controller
             JSON_UNESCAPED_UNICODE
         );
     }
+
+
+    /**
+     * Display the specified resources.
+     * 
+     * 
+     */
+    public function show(Genre $genre){
+
+        $genre->setVisible([
+            'id',
+            'name',
+        ]);
+
+        return response()->json(
+            $genre,
+            200,
+            [],
+            JSON_UNESCAPED_UNICODE
+        );
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -41,3 +41,4 @@ Route::get('users/{userId}/user_books','UserBookController@index');
  * 
  */
 Route::get('genres','GenreController@index');
+Route::get('genres/{genre}', 'GenreController@show');


### PR DESCRIPTION
connect to #40 
close #40

# 概要
ジャンルIDを受けたときにジャンル詳細（名称のみ）をJSONで返すAPI実装

# 主な変更点
- ルート定義
- ジャンルコントローラのshowアクション実装

# レスポンス例
![default](https://user-images.githubusercontent.com/29668738/48387278-7f04b580-e738-11e8-9296-2a616b893ec8.PNG)