### PR TITLE
guzzlehttp/guzzleを依存関係に追加

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "php": "^7.1.3",
         "doctrine/dbal": "^2.8",
         "fideloper/proxy": "^4.0",
+        "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "5.7.*",
         "laravel/passport": "^7.0",
         "laravel/tinker": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "188ea09469be6fcb27fada582216aa6b",
+    "content-hash": "78fcad8fed17c8e2d6dbbfa28d14e52d",
     "packages": [
         {
             "name": "defuse/php-encryption",


### PR DESCRIPTION
connect to #89 
close #89 

# 概要
guzzlehttp/guzzleを依存関係に追加

# 主な変更点
- composer.jsonにguzzlehttp/guzzleへの依存を追加。
- composer.lockを更新

# 備考

マージしたら各々の環境で`composer install`を実行する必要がある。

# 戯言
サービスコンテナに追加する必要があると思っていた。
しかしコンストラクタインジェクションをする際に自動的にクラス名から解決してくれるため、
サービスプロバイダを追加したり更新する必要はなかった。