### PR TITLE
Google Books API を叩いてApp\Bookをマネージャに渡すスクレイパークラスの実装#70

### DIFF
--- a/app/Book.php
+++ b/app/Book.php
@@ -6,6 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class Book extends Model
 {
+    // 自動増分の抑制
+    public $incrementing = false;
+    // 'id'ではない主キーの設定
+    protected $primaryKey = 'isbn';
 
     /**
      * リレーション定義

--- a/app/Components/BookInfoScraper/GoogleBooksScraper.php
+++ b/app/Components/BookInfoScraper/GoogleBooksScraper.php
@@ -7,6 +7,9 @@ use App\Book;
 
 class GoogleBooksScraper implements ScraperInterface
 {
+    // APIのエントリポイント
+    private const URI = "https://www.googleapis.com/books/v1/volumes?q=";
+
     /**
      *  コンストラクタ
      * 
@@ -19,7 +22,7 @@ class GoogleBooksScraper implements ScraperInterface
      * GoogleBooksAPIを叩き、本の情報を取得する。
      * その情報をもとにApp\Bookに情報を格納してマネージャに返す。
      * 
-     * @pram string $isbn
+     * @param string $isbn
      *  正規化されたISBN
      * 
      * @return App\Book | null
@@ -28,35 +31,31 @@ class GoogleBooksScraper implements ScraperInterface
      */
     public function searchByIsbn(string $isbn){
 
-        // APIのエントリポイント。
-        $base_url = "https://www.googleapis.com/books/v1/volumes?q=";
-
         // GuzzleHttp\Clientのインスタンスを生成。
         // 正規化されたISBN文字列をクエリパラメータとしてリクエストを送る。
         $client = new Client();
-        $response = $client->request('GET', ($base_url . $isbn))
+        $response = $client->request('GET', (self::URI . $isbn))
                            ->getBody();
 
         // JSON形式にデコード
         $bookInfo = json_decode($response);
 
-        // レスポンスがあればBookモデルを返し、なければnullを返す
-        if( $bookInfo->totalItems === 0){
-            return null;
-        } else {
-            // App\Bookのインスタンスを生成。
-            $book = new Book;
+        // レスポンスなければnullを返す
+        if( $bookInfo->totalItems === 0) return null;
 
-            // レスポンスで得た情報を該当カラムに格納する。
-            $book->isbn = $bookInfo->items[0]->volumeInfo->industryIdentifiers[1]->identifier;
-            $book->name = $bookInfo->items[0]->volumeInfo->title;
-            $book->description = $bookInfo->items[0]->volumeInfo->description;
-            $book->conver = $bookInfo->items[0]->volumeInfo->imageLinks->smallThumbnail;
-            $book->author = $bookInfo->items[0]->volumeInfo->authors;
-            // $book->genre_id = $bookInfo->items[0]->volumeInfo->categories;
+        // App\Bookのインスタンスを生成。
+        $book = new Book;
 
-            // App\Bookをスクレイプマネージャに返す
-            return $book;
-        }
+        // レスポンスで得た情報を該当カラムに格納する。
+        $book->isbn = $bookInfo->items[0]->volumeInfo->industryIdentifiers[1]->identifier;
+        $book->name = $bookInfo->items[0]->volumeInfo->title;
+        $book->description = $bookInfo->items[0]->volumeInfo->description;
+        $book->conver = $bookInfo->items[0]->volumeInfo->imageLinks->smallThumbnail;
+        $book->author = $bookInfo->items[0]->volumeInfo->authors;
+        // $book->genre_id = $bookInfo->items[0]->volumeInfo->categories;
+
+        // App\Bookをスクレイプマネージャに返す
+        return $book;
+    
     }
 }

--- a/app/Components/BookInfoScraper/GoogleBooksScraper.php
+++ b/app/Components/BookInfoScraper/GoogleBooksScraper.php
@@ -48,7 +48,7 @@ class GoogleBooksScraper implements ScraperInterface
             $book = new Book;
 
             // レスポンスで得た情報を該当カラムに格納する。
-            $book->id = $bookInfo->items[0]->volumeInfo->industryIdentifiers[1]->identifier;
+            $book->isbn = $bookInfo->items[0]->volumeInfo->industryIdentifiers[1]->identifier;
             $book->name = $bookInfo->items[0]->volumeInfo->title;
             $book->description = $bookInfo->items[0]->volumeInfo->description;
             $book->conver = $bookInfo->items[0]->volumeInfo->imageLinks->smallThumbnail;

--- a/app/Components/BookInfoScraper/GoogleBooksScraper.php
+++ b/app/Components/BookInfoScraper/GoogleBooksScraper.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Components\BookInfoScraper;
+
+use GuzzleHttp\Client;
+use App\Book;
+
+class GoogleBooksScraper implements ScraperInterface
+{
+    /**
+     *  コンストラクタ
+     * 
+     */
+    public function __construct(){
+    }
+
+    /**
+     * ScrapeInterface::searchByIsbn()の実装
+     * GoogleBooksAPIを叩き、本の情報を取得する。
+     * その情報をもとにApp\Bookに情報を格納してマネージャに返す。
+     * 
+     * @pram string $isbn
+     *  正規化されたISBN
+     * 
+     * @return App\Book | null
+     *  戻り値があればApp\Bookにして返す。
+     *  なかった場合はnullを返す。
+     */
+    public function searchByIsbn(string $isbn){
+
+        // APIのエントリポイント。
+        $base_url = "https://www.googleapis.com/books/v1/volumes?q=";
+
+        // GuzzleHttp\Clientのインスタンスを生成。
+        // 正規化されたISBN文字列をクエリパラメータとしてリクエストを送る。
+        $client = new Client();
+        $response = $client->request('GET', ($base_url . $isbn))
+                           ->getBody();
+
+        // JSON形式にデコード
+        $bookInfo = json_decode($response);
+
+        // レスポンスがあればBookモデルを返し、なければnullを返す
+        if( $bookInfo->totalItems === 0){
+            return null;
+        } else {
+            // App\Bookのインスタンスを生成。
+            $book = new Book;
+
+            // レスポンスで得た情報を該当カラムに格納する。
+            $book->id = $bookInfo->items[0]->volumeInfo->industryIdentifiers[1]->identifier;
+            $book->name = $bookInfo->items[0]->volumeInfo->title;
+            $book->description = $bookInfo->items[0]->volumeInfo->description;
+            $book->conver = $bookInfo->items[0]->volumeInfo->imageLinks->smallThumbnail;
+            $book->author = $bookInfo->items[0]->volumeInfo->authors;
+            // $book->genre_id = $bookInfo->items[0]->volumeInfo->categories;
+
+            // App\Bookをスクレイプマネージャに返す
+            return $book;
+        }
+    }
+}

--- a/app/Components/BookInfoScraper/ScraperInterface.php
+++ b/app/Components/BookInfoScraper/ScraperInterface.php
@@ -13,9 +13,9 @@ interface ScraperInterface
      *  検索対象ISBN。
      *  ISBN10の場合、プレフィックス978のISBN13に変換して検索する。
      * 
-     * @return  \App\Book|false
+     * @return  \App\Book|null
      *  見つかった場合はApp\Bookモデルを返す。
-     *  見つからなかった場合はfalseを返す
+     *  見つからなかった場合はnullを返す。
      */
     public function searchByIsbn(string $isbn);
 }

--- a/app/Providers/BookInfoScraperServiceProvider.php
+++ b/app/Providers/BookInfoScraperServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Components\BookInfoScraper\ScrapeManager;
+use App\Components\BookInfoScraper\GoogleBooksScraper;
 use Illuminate\Support\ServiceProvider;
 
 class BookInfoScraperServiceProvider extends ServiceProvider
@@ -24,6 +25,19 @@ class BookInfoScraperServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        // GoogleBooksScraperをコンテナに登録
+        $this->app->bind(
+            'GoogleBooksScraper',
+            function(){
+                return new GoogleBooksScraper();
+            }
+        );
+
+        // tag付け
+        $this->app->tag(['GoogleBooksScraper'], 'app.bookInfo.scraper');
+
+        // ScrapeManagerをコンテナに登録
+        // コンストラクタに引数として'app.bookInfo.scraper'のタグを持つ各スクレイパーを渡す
         $this->app->bind(
             'app.bookInfo.scrapeManager',
             function ($app) {

--- a/database/factories/BookFactory.php
+++ b/database/factories/BookFactory.php
@@ -4,6 +4,7 @@ use Faker\Generator as Faker;
 
 $factory->define(App\Book::class, function (Faker $faker) {
     return [
+        'isbn' => (int)($faker->isbn13),
         'name' => $faker->sentence($nbWords = 4, $variableNbWords = false),
         'description' => $faker->realText($maxNbChars = 255, $indexSize = 2),
         'cover' => 'http://books.google.com/books/content?id=_42rGAAACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api',

--- a/database/migrations/2018_11_02_133709_create_books_table.php
+++ b/database/migrations/2018_11_02_133709_create_books_table.php
@@ -14,7 +14,7 @@ class CreateBooksTable extends Migration
     public function up()
     {
         Schema::create('books', function (Blueprint $table) {
-            $table->increments('id');
+            $table->unsignedInteger('isbn');
             $table->string('name');
             $table->string('description');
             $table->string('cover');

--- a/database/migrations/2018_11_02_143901_create_user_books_table.php
+++ b/database/migrations/2018_11_02_143901_create_user_books_table.php
@@ -23,7 +23,7 @@ class CreateUserBooksTable extends Migration
                 ->references('id')->on('users')
                 ->onDelete('cascade');
             $table->foreign('book_id')
-                ->references('id')->on('books')
+                ->references('isbn')->on('books')
                 ->onDelete('cascade');
 
             $table->unique(['user_id', 'book_id']);


### PR DESCRIPTION
connect to #70
close #70

# 概要
ScrapeManagerが使役するスクレイパークラス実装の一つ。
正規化された13桁のISBNを引数に取りGoogle Books API を叩く。
得られた情報をもとにApp\Bookを返し、情報がない場合はnullを返す。

# 主な変更点
・GoogleBooksScraperクラスの追加、実装
・GoogleBooksScraperクラスのコンテナへの登録とタグ付け
・booksテーブルの主キーの変更、およびそれに伴うbook_userテーブルの外部参照の変更
・booksテーブル用のファクトリークラスでISBN13を自動生成し主キーに設定するように修正

# Guzzleで取得したGoogle Books API のレスポンスから作ったApp\Bookの例
![default](https://user-images.githubusercontent.com/29668738/49131707-845b2600-f31c-11e8-85ca-27a7d356adef.PNG)

# 注意点
・ジャンルの取得は行っておらず、ジャンル取得はScrapeManager側で処理するように実装する必要がある
・booksテーブルの主キーをISBN13に変更したことで、バルク挿入しているほかのサンプルデータで、以前のbooksのid（1とか2とか）に依拠しているものの意味がなくなる可能性がある
※一応、`php artisan migrate:refresh --seed`は問題なく通る