### PR TITLE
Fix devtools bug

### DIFF
--- a/resources/js/store.js
+++ b/resources/js/store.js
@@ -1,9 +1,10 @@
 import { createStore, applyMiddleware } from "redux";
 import thunkMiddleware from "redux-thunk";
-import { composeWithDevTools } from "redux-devtools-extension";
+// HACK: こいつが2.16.x系では、storeを生成した後にdispatchを実行するとエラーが出るので一旦使わない
+// import { composeWithDevTools } from "redux-devtools-extension";
 import { rootReducer } from "./reducers";
 
 export const store = createStore(
     rootReducer,
-    composeWithDevTools(applyMiddleware(thunkMiddleware))
+    applyMiddleware(thunkMiddleware)
 );


### PR DESCRIPTION
connect to #
close #

# 概要

redux-devtools-extensionの2.16.x系では、storeを生成した後にdispatchを実行するとエラーが出るので一旦使わないようにした。

# 参考

- https://github.com/zalmoxisus/redux-devtools-extension/issues/590
