### PR TITLE
Add fetch wrapper

### DIFF
--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -34,6 +34,12 @@ export async function wrapFetch({ url, method = "GET", body, isParse = true }) {
     }
     return null;
 }
+export function _mix(actionCreator, callback) {
+    return (...args) => {
+        return actionCreator(...args)
+            .then(json => callback(json));
+    }
+}
 
 
 export const setTimeLine = timeLine => ({ type: "SET_TIMELINE", timeLine });

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -8,6 +8,8 @@ export async function wrapFetch(url, { body, method = "GET", isParse = true } = 
     // GETリクエスト時にクエリパラメーターを自動作成する
     if(method === "GET" && !utils.isEmpty(body)) {
         url += "?" + utils.convertQuery(body);
+    } else if(!utils.isEmpty(body)) { // not get request && body not empty
+        body = JSON.stringify(body);
     }
 
     const res = await fetch(url, {
@@ -53,7 +55,7 @@ export const setAuthToken = (token) => ({ type: "SET_AUTH_TOKEN", token });
 export const requestLogin = (loginUser) => dispatch => {
     wrapFetch(DOMAIN + "/api/login", {
         method: "POST",
-        body: JSON.stringify(loginUser)
+        body: loginUser
     }).then(json => {
         dispatch(setAuthToken(json.token));
     });

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -97,30 +97,26 @@ export const fetchGenres = () => dispatch => {
 
 export const setBookDetail = bookDetail => ({type: "SET_BOOK_DETAIL", bookDetail});
 export const fetchBookDetail = (id) => dispatch => {
-    fetch(DOMAIN + `/api/books/${id}`)
-        .then(res => res.json())
+    wrapFetch(DOMAIN + `/api/books/${id}`)
         .then(json => {
             dispatch(setBookDetail(json));
-    })
+        });
 }
 
 export const setUsersBookshelf = usersBookshelf => ({type: "SET_USERS_BOOKSHELF", usersBookshelf});
 export const fetchUsersBookshelf = (userId) => dispatch => {
-    fetch(DOMAIN + `/api/users/${userId}/user_books`)
-        .then(res => res.json())
+    wrapFetch(DOMAIN + `/api/users/${userId}/user_books`)
         .then(json => {
             dispatch(setUsersBookshelf(json));
-        })
+        });
 }
 
 export const setBookList = books => ({type: "SET_BOOKLIST", books});
 export const fetchBookList = () => dispatch => {
-    fetch(DOMAIN + "/api/books/")
-        .then(res => res.json())
+    wrapFetch(DOMAIN + "/api/books/")
         .then(json => {
             dispatch(setBookList(json));
-        })
-        .catch(err => {
-            console.error("fetch error", err);
+        }).catch(err => {
+            console.error("fetchBookList: ", err);
         });
 }

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -1,5 +1,13 @@
 import { DOMAIN } from "./domain";
 
+export function successfulStatus(code) {
+    if(code / 100 == 2) {
+        return true;
+    }
+    return false;
+}
+
+
 export const setTimeLine = timeLine => ({ type: "SET_TIMELINE", timeLine });
 export const fetchTimeLine = () => dispatch => {
     const timeLine = [

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -1,9 +1,12 @@
 import { DOMAIN } from "./domain";
 import * as utils from "./utils";
 
+
+// fetch関数を綺麗に扱えるようにするラッパー関数
 export async function wrapFetch({ url, method = "GET", body, isParse = true }) {
-    if(method === "GET") {
-        url += "?" + convertQuery(body);
+    // GETリクエスト時にクエリパラメーターを自動作成する
+    if(method === "GET" && !utils.isEmpty(body)) {
+        url += "?" + utils.convertQuery(body);
     }
 
     const res = await fetch(url, {

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -6,6 +6,11 @@ export function successfulStatus(code) {
     }
     return false;
 }
+export function convertQuery(obj) {
+    return Object.keys(body).map((key) => {
+        return key + "=" + body[key];
+    }).join('&')
+}
 
 
 export const setTimeLine = timeLine => ({ type: "SET_TIMELINE", timeLine });

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -1,5 +1,6 @@
 import { DOMAIN } from "./domain";
 import * as utils from "./utils";
+import { store } from "./store";
 
 
 // fetch関数を綺麗に扱えるようにするラッパー関数
@@ -90,17 +91,11 @@ export const requestUserRegister = (userInfo) => dispatch => {
 
 export const setGenres = genres => ({ type: "SET_GENRES", genres });
 export const fetchGenres = () => dispatch => {
-    fetch( DOMAIN + "/api/genres/", {
-        timeout: 3000,
-        method: "GET"
-    })
-        .then(res => res.json())
-        .then(json => {
-                dispatch(setGenres(json));
-        })
-        .catch(err => {
-            console.error("fetch error!", err);
-        });
+    wrapFetch({
+        url: DOMAIN + "/api/genres",
+    }).then(json => {
+        dispatch(setGenres(json));
+    });
 }
 
 export const setBookDetail = bookDetail => ({type: "SET_BOOK_DETAIL", bookDetail});

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -41,13 +41,6 @@ export function wrapAction(actionCreator, callback) {
 
 
 export const setTimeLine = timeLine => ({ type: "SET_TIMELINE", timeLine });
-export const fetchTimeLine = () => dispatch => {
-    const timeLine = [
-      { name: "bok1" },
-      { name: "bok2" },
-    ];
-    dispatch(setTimeLine(timeLine));
-}
 
 /* ==== Auth actions ==== */
 // Get authentication token

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -64,10 +64,11 @@ export const requestLogin = (loginUser) => dispatch => {
 
 export const removeAuthToken = () => ({ type: "REMOVE_AUTH_TOKEN" });
 export const requestLogout = () => dispatch => {
-    fetch(DOMAIN + "/api/logout")
-        .then(res => {
-            dispatch(removeAuthToken());
-        });
+    wrapFetch(DOMAIN + "/api/logout", {
+        isParse: false,
+    }).then(res => {
+        dispatch(removeAuthToken());
+    });
 }
 
 export const requestUserRegister = (userInfo) => dispatch => {

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -15,11 +15,11 @@ export async function wrapFetch({ url, method = "GET", body, isParse = true }) {
             Accept: "application/json",
             "Content-Type": "application/json",
         },
-        body: method === "GET" ? null : body
+        body: method === "GET" ? null : body // GET時はクエリで代用するため
     });
 
-    if(successfulStatus(res.status)) {
-        throw new Error("fetch error" + res.statusText);
+    if(!utils.successfulStatus(res.status)) {
+        throw new Error("fetch error: " + res.statusText);
     }
 
     if(isParse) {

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -4,7 +4,7 @@ import { store } from "./store";
 
 
 // fetch関数を綺麗に扱えるようにするラッパー関数
-export async function wrapFetch({ url, method = "GET", body, isParse = true }) {
+export async function wrapFetch(url, { body, method = "GET", isParse = true } = {}) {
     // GETリクエスト時にクエリパラメーターを自動作成する
     if(method === "GET" && !utils.isEmpty(body)) {
         url += "?" + utils.convertQuery(body);

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -27,7 +27,9 @@ export async function wrapFetch({ url, method = "GET", body, isParse = true }) {
     }
     return null;
 }
-export function _mix(actionCreator, callback) {
+
+// 封印されしラッパー関数
+export function wrapAction(actionCreator, callback) {
     return (...args) => {
         return actionCreator(...args)
             .then(json => callback(json));

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -1,16 +1,6 @@
 import { DOMAIN } from "./domain";
+import * as utils from "./utils";
 
-export function successfulStatus(code) {
-    if(code / 100 == 2) {
-        return true;
-    }
-    return false;
-}
-export function convertQuery(obj) {
-    return Object.keys(body).map((key) => {
-        return key + "=" + body[key];
-    }).join('&')
-}
 export async function wrapFetch({ url, method = "GET", body, isParse = true }) {
     if(method === "GET") {
         url += "?" + convertQuery(body);

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -2,6 +2,11 @@ import { DOMAIN } from "./domain";
 import * as utils from "./utils";
 import { store } from "./store";
 
+// stateの値を取得し、自動更新する
+let state = store.getState();
+store.subscribe(() => {
+    state = store.getState();
+});
 
 // fetch関数を綺麗に扱えるようにするラッパー関数
 export async function wrapFetch(url, { body, method = "GET", isParse = true } = {}) {
@@ -17,12 +22,15 @@ export async function wrapFetch(url, { body, method = "GET", isParse = true } = 
         headers: {
             Accept: "application/json",
             "Content-Type": "application/json",
+            "Authorization": `Bearer ${state.token}`,
         },
         body: method === "GET" ? null : body // GET時はクエリで代用するため
     });
 
-    if(!utils.successfulStatus(res.status)) {
-        throw new Error("fetch error: " + res.statusText);
+    if(res.status === 401) {
+        throw new Error("Authorization error: " + res.statusText);
+    } else if(!utils.successfulStatus(res.status)) {
+        throw new Error("Fetch error: " + res.statusText);
     }
 
     if(isParse) {

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -91,11 +91,10 @@ export const requestUserRegister = (userInfo) => dispatch => {
 
 export const setGenres = genres => ({ type: "SET_GENRES", genres });
 export const fetchGenres = () => dispatch => {
-    wrapFetch({
-        url: DOMAIN + "/api/genres",
-    }).then(json => {
-        dispatch(setGenres(json));
-    });
+    wrapFetch(DOMAIN + "/api/genres")
+        .then(json => {
+            dispatch(setGenres(json));
+        });
 }
 
 export const setBookDetail = bookDetail => ({type: "SET_BOOK_DETAIL", bookDetail});

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -11,6 +11,29 @@ export function convertQuery(obj) {
         return key + "=" + body[key];
     }).join('&')
 }
+export async function wrapFetch({ url, method = "GET", body, isParse = true }) {
+    if(method === "GET") {
+        url += "?" + convertQuery(body);
+    }
+
+    const res = await fetch(url, {
+        method,
+        headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+        },
+        body: method === "GET" ? null : body
+    });
+
+    if(successfulStatus(res.status)) {
+        throw new Error("fetch error" + res.statusText);
+    }
+
+    if(isParse) {
+        return await res.json();
+    }
+    return null;
+}
 
 
 export const setTimeLine = timeLine => ({ type: "SET_TIMELINE", timeLine });

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -51,18 +51,12 @@ export const fetchTimeLine = () => dispatch => {
 // Get authentication token
 export const setAuthToken = (token) => ({ type: "SET_AUTH_TOKEN", token });
 export const requestLogin = (loginUser) => dispatch => {
-    fetch(DOMAIN + "/api/login", {
+    wrapFetch(DOMAIN + "/api/login", {
         method: "POST",
-        headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json",
-        },
         body: JSON.stringify(loginUser)
-    })
-        .then(res => res.json())
-        .then(json => {
-            dispatch(setAuthToken(json.token));
-        });
+    }).then(json => {
+        dispatch(setAuthToken(json.token));
+    });
 }
 
 export const removeAuthToken = () => ({ type: "REMOVE_AUTH_TOKEN" });

--- a/resources/js/components/Header.jsx
+++ b/resources/js/components/Header.jsx
@@ -25,6 +25,7 @@ const Header = () => (
                     <Link className="nav-item nav-link" to="/">ホーム <span className="sr-only">(current)</span></Link>
                     <Link className="nav-item nav-link" to="/signup">新規登録</Link>
                     <Link className="nav-item nav-link" to="/login">ログイン</Link>
+                    <Link className="nav-item nav-link" to="/logout">ログアウト</Link>
                     <Link className="nav-item nav-link" to="/mypage">マイページ</Link>
                     <Link className="nav-item nav-link" to="/books">本一覧</Link>
                     <Link className="nav-item nav-link" to="/books/1">本詳細</Link>

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 
-import { fetchTimeLine } from "./actions";
 import { App } from "./components/App";
 import { store } from "./store";
 

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -8,10 +8,7 @@ export function isEmpty(obj) {
 
 // ステータスコードが200番代か判定する
 export function successfulStatus(code) {
-    if(code / 100 == 2) {
-        return true;
-    }
-    return false;
+    return (code / 100 == 2);
 }
 
 // オブジェクトを受け取って、GETリクエストのクエリパラメーターに変換する

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -5,3 +5,18 @@ export function isEmpty(obj) {
       return !obj || !Object.keys(obj).length;
     }
 }
+
+// ステータスコードが200番代か判定する
+export function successfulStatus(code) {
+    if(code / 100 == 2) {
+        return true;
+    }
+    return false;
+}
+
+// オブジェクトを受け取って、GETリクエストのクエリパラメーターに変換する
+export function convertQuery(obj) {
+    return Object.keys(body).map((key) => {
+        return key + "=" + body[key];
+    }).join('&')
+}


### PR DESCRIPTION
connect to #125 
close #125 

# 概要

Actionをもっと綺麗にかけるように、ラッパー関数を作成

# 主な変更点

- `fetch`を綺麗にかけるように、`wrapFetch`というラッパー関数を作成
- `fetch`関数の代わりに、`wrapFetch`関数を使うように変更
- ラッパー関数を作るときに必要になった諸々のutil関数を追加
- `wrapFetch`を使うと自動的にログイン認証トークンを送信してくれるようになった
(ログインしていないと当然ダメだが。ついでにurl直打ちで画面遷移するとstoreの値が初期化されるのでログインしてもトークンが消える)
- `wrapAction`は今後コードが煩雑になってきたときに使うかもしれないが、今は使っていない。
(使ってないなら消せよ、という話だがこれをもう一度直ぐに書けると思えないので残している)