### PR TITLE
国会図書館APIを叩いてスクレイプマネージャにBookを返すクラス実装#72

### DIFF
--- a/app/Components/BookInfoScraper/GoogleBooksScraper.php
+++ b/app/Components/BookInfoScraper/GoogleBooksScraper.php
@@ -50,7 +50,7 @@ class GoogleBooksScraper implements ScraperInterface
         $book->isbn = $bookInfo->items[0]->volumeInfo->industryIdentifiers[1]->identifier;
         $book->name = $bookInfo->items[0]->volumeInfo->title;
         $book->description = $bookInfo->items[0]->volumeInfo->description;
-        $book->conver = $bookInfo->items[0]->volumeInfo->imageLinks->smallThumbnail;
+        $book->cover = $bookInfo->items[0]->volumeInfo->imageLinks->smallThumbnail;
         $book->author = $bookInfo->items[0]->volumeInfo->authors;
         // $book->genre_id = $bookInfo->items[0]->volumeInfo->categories;
 

--- a/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
+++ b/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
@@ -22,10 +22,10 @@ class NationalDietLibraryScraper implements ScraperInterface
      *  ScrapeInterface::searchByIsbn()の実装
      *  国会図書館のAPIを叩き、本の情報を取得する。
      *  その情報をもとにApp\Bookに情報を格納してマネージャに返す。
-     * 
+     *
      *  @param string $isbn
      *   正規化されたISBN
-     * 
+     *
      *  @return App\Book | null
      *   戻り値があればApp/Bookにして返す。
      *   なかった場合はnullを返す。
@@ -54,7 +54,7 @@ class NationalDietLibraryScraper implements ScraperInterface
         $dcBookInfoXML = $xml->channel->item->children($nameSpaces['dc']);
         // JSONオブジェクトに変換
         $dcBookInfoJSON = json_decode(json_encode($dcBookInfoXML, true));
-        
+
         $book = new Book;
 
         $book->isbn = (int)($isbn);

--- a/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
+++ b/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
@@ -46,14 +46,12 @@ class NationalDietLibraryScraper implements ScraperInterface
         $nameSpaces = $xml->getNamespaces(true);
 
         // channel配下にある名前空間'openSearch'を取得する
-        $channel = $xml->channel;
-        $channelBookInfoXML = $channel->children($nameSpaces['openSearch']);
+        $channelBookInfoXML = $xml->channel->children($nameSpaces['openSearch']);
         // 検索結果が0件ならばnullを返す
         if( $channelBookInfoXML->totalResults[0] == 0) return null;
 
         // item配下にある名前空間'dc'の要素を取得する
-        $item = $xml->channel->item;
-        $dcBookInfoXML = $item->children($nameSpaces['dc']);
+        $dcBookInfoXML = $xml->channel->item->children($nameSpaces['dc']);
         // JSONオブジェクトに変換
         $dcBookInfoJSON = json_decode(json_encode($dcBookInfoXML, true));
         

--- a/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
+++ b/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Components\BookInfoScraper;
+
+use GuzzleHttp\Client;
+use App\Book;
+
+class NationalDietLibraryScraper implements ScraperInterface
+{
+    // APIのエントリポイント
+    private const URI = "http://iss.ndl.go.jp/api/opensearch?isbn=";
+
+    /**
+     *  コンストラクタ
+     * 
+     */
+    public function __construct(){
+
+    }
+
+    /**
+     *  ScrapeInterface::searchByIsbn()の実装
+     *  国会図書館のAPIを叩き、本の情報を取得する。
+     *  その情報をもとにApp\Bookに情報を格納してマネージャに返す。
+     * 
+     *  @param string $isbn
+     *   正規化されたISBN
+     * 
+     *  @return App\Book | null
+     *   戻り値があればApp/Bookにして返す。
+     *   なかった場合はnullを返す。
+     */
+    public function searchByIsbn(string $isbn){
+
+        // GuzzleHttp\Clientのインスタンスを生成。
+        // 正規化されたISBN文字列をクエリパラメータとしてリクエストを送る。
+        $client = new Client();
+        $response = $client->request('GET', (self::URI . $isbn))
+                           ->getBody()
+                           ->getContents();
+
+        // 文字列$responseをSimpleXMLElementにパースする
+        $xml = simplexml_load_string($response);
+
+        // XML内の名前空間を取得
+        $nameSpaces = $xml->getNamespaces(true);
+
+        // channel配下にある名前空間'openSearch'を取得する
+        $channel = $xml->channel;
+        $channelBookInfoXML = $channel->children($nameSpaces['openSearch']);
+        // 検索結果が0件ならばnullを返す
+        if( $channelBookInfoXML->totalResults[0] == 0) return null;
+
+        // item配下にある名前空間'dc'の要素を取得する
+        $item = $xml->channel->item;
+        $dcBookInfoXML = $item->children($nameSpaces['dc']);
+        // JSONオブジェクトに変換
+        $dcBookInfoJSON = json_decode(json_encode($dcBookInfoXML, true));
+        
+        $book = new Book;
+
+        $book->isbn = (int)($isbn);
+        $book->name = $dcBookInfoJSON->title;
+        $book->description = $dcBookInfoJSON->description;
+        $book->cover = "";
+        $book->author = str_replace(", ", "", $dcBookInfoJSON->creator);
+
+        return $book;
+    }
+}

--- a/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
+++ b/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
@@ -24,7 +24,7 @@ class NationalDietLibraryScraper implements ScraperInterface
      * 
      * @param $bookInfoAuthor
      * 
-     * @return $consAuthors | $bookInfo
+     * @return $consAuthors | $bookInfoAuthor
      *   引数に渡されたものが配列であれば文字列に連結して返す。
      * 　配列でない場合はそのまま返す。
      */
@@ -40,6 +40,8 @@ class NationalDietLibraryScraper implements ScraperInterface
     }
 
     /**
+     * 本の概要情報の整形処理
+     * 
      * @param $bookInfoDescription
      * 
      * @return $consDescription | $bookInfoDescription
@@ -90,7 +92,7 @@ class NationalDietLibraryScraper implements ScraperInterface
         // channel配下にある名前空間'openSearch'を取得する
         $channelBookInfoXML = $xml->channel->children($nameSpaces['openSearch']);
         // 検索結果が0件ならばnullを返す
-        if( $channelBookInfoXML->totalResults[0] == 0) return null;
+        if($channelBookInfoXML->totalResults[0] == 0) return null;
 
         // item配下にある名前空間'dc'の要素を取得する
         $dcBookInfoXML = $xml->channel->item->children($nameSpaces['dc']);

--- a/app/Providers/BookInfoScraperServiceProvider.php
+++ b/app/Providers/BookInfoScraperServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Components\BookInfoScraper\ScrapeManager;
 use App\Components\BookInfoScraper\GoogleBooksScraper;
+use App\Components\BookInfoScraper\NationalDietLibraryScraper;
 use Illuminate\Support\ServiceProvider;
 
 class BookInfoScraperServiceProvider extends ServiceProvider
@@ -33,8 +34,20 @@ class BookInfoScraperServiceProvider extends ServiceProvider
             }
         );
 
+        // NationalDietLibraryScraperをコンテナに登録
+        $this->app->bind(
+            'NationalDietLibraryScraper',
+            function(){
+                return new NationalDietLibraryScraper();
+            }
+        );
+
         // tag付け
-        $this->app->tag(['GoogleBooksScraper'], 'app.bookInfo.scraper');
+        $this->app->tag([
+                        'GoogleBooksScraper',
+                        'NationalDietLibraryScraper'
+                        ],
+                        'app.bookInfo.scraper');
 
         // ScrapeManagerをコンテナに登録
         // コンストラクタに引数として'app.bookInfo.scraper'のタグを持つ各スクレイパーを渡す


### PR DESCRIPTION
connect to #72 
close #72

# 概要
- 国会図書館APIを叩いて本情報を取得。
- 書影データについては、別途用意されている書影用APIを利用する。
- XMLデータでのレスポンスしか利用できないことに加えて、レスポンスデータの形状にバラつきがあるため、国会図書館専用のロジックになっている。

# 主な変更点
- NationalDietLibraryScraperクラスの実装
- NationalDietLibraryScraperクラスをコンテナに登録＆tag付け
- coverのタイポ修正

# レスポンスデータ例
![default](https://user-images.githubusercontent.com/29668738/49354767-c82ca180-f707-11e8-9b44-3a346ffafde3.PNG)