### PR TITLE
Fix like love table

### DIFF
--- a/app/Bok.php
+++ b/app/Bok.php
@@ -11,7 +11,7 @@ class Bok extends Model
         return $this->belongsTo(User::class);
     }
 
-    public function userBook(){
+    public function bookUser(){
         return $this->belongsTo(BookUser::class);
     }
 

--- a/app/Book.php
+++ b/app/Book.php
@@ -21,4 +21,8 @@ class Book extends Model
     public function users(){
         return $this->belongsToMany(User::class);
     }
+
+    public function userBook() {
+        return $this->hasMany(BookUser::class);
+    }
 }

--- a/app/Book.php
+++ b/app/Book.php
@@ -22,7 +22,7 @@ class Book extends Model
         return $this->belongsToMany(User::class);
     }
 
-    public function userBook() {
+    public function bookUser() {
         return $this->hasMany(BookUser::class);
     }
 }

--- a/app/BookUser.php
+++ b/app/BookUser.php
@@ -22,4 +22,8 @@ class BookUser extends Model
     public function user(){
         return $this->belongsTo(User::class);
     }
+
+    public function book() {
+        return $this->belongsTo(Book::class, 'book_id');
+    }
 }

--- a/app/Http/Controllers/ReactionController.php
+++ b/app/Http/Controllers/ReactionController.php
@@ -8,15 +8,6 @@ use Illuminate\Http\Request;
 
 class ReactionController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-    }
-
     public function likes($userId)
     {
         $likes = User::find($userId)->likes();
@@ -26,71 +17,5 @@ class ReactionController extends Controller
             [],
             JSON_UNESCAPED_UNICODE
         );
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
-     *
-     * @param  \App\Reaction  $reaction
-     * @return \Illuminate\Http\Response
-     */
-    public function show(Reaction $reaction)
-    {
-        //
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  \App\Reaction  $reaction
-     * @return \Illuminate\Http\Response
-     */
-    public function edit(Reaction $reaction)
-    {
-        //
-    }
-
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \App\Reaction  $reaction
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, Reaction $reaction)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  \App\Reaction  $reaction
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy(Reaction $reaction)
-    {
-        //
     }
 }

--- a/app/Http/Controllers/ReactionController.php
+++ b/app/Http/Controllers/ReactionController.php
@@ -19,7 +19,7 @@ class ReactionController extends Controller
 
     public function likes($userId)
     {
-        $likes = User::find($userId)->likes;
+        $likes = User::find($userId)->likes();
         return response()->json(
             $likes,
             200,

--- a/app/Http/Controllers/ReactionController.php
+++ b/app/Http/Controllers/ReactionController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Reaction;
+use App\User;
+use Illuminate\Http\Request;
+
+class ReactionController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+    }
+
+    public function likes($userId)
+    {
+        $likes = User::find($userId)->likes;
+        return response()->json(
+            $likes,
+            200,
+            [],
+            JSON_UNESCAPED_UNICODE
+        );
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Reaction  $reaction
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Reaction $reaction)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Reaction  $reaction
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(Reaction $reaction)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Reaction  $reaction
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, Reaction $reaction)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Reaction  $reaction
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Reaction $reaction)
+    {
+        //
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\DB;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +14,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        DB::listen(function ($query) {
+            $sql = $query->sql;
+            foreach($query->bindings as $bind) {
+                $sql = preg_replace("/\?/", $bind, $sql, 1);
+            }
+            logger($sql);
+        });
     }
 
     /**

--- a/app/Reaction.php
+++ b/app/Reaction.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Reaction extends Model
+{
+    protected $fillable = [
+        'user_id', 'bok_id', 'liked', 'loved',
+    ];
+}

--- a/app/Reaction.php
+++ b/app/Reaction.php
@@ -9,4 +9,13 @@ class Reaction extends Model
     protected $fillable = [
         'user_id', 'bok_id', 'liked', 'loved',
     ];
+
+    public function user() {
+        return $this->belongsTo(User::class);
+    }
+
+    public function bok() {
+        return $this->belongsTo(Bok::class);
+    }
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -47,7 +47,12 @@ class User extends Authenticatable
     }
 
     public function likes(){
-        return $this->belongsToMany(Bok::class, 'reactions', 'user_id', 'bok_id')
-            ->wherePivot('liked', 1);
+        return \App\Reaction::where('user_id', $this->id)->where('liked', 1)
+            ->with([
+                'user:id,name,avatar,description',
+                'bok:id,user_id,body,page_num_begin,page_num_end,published_at,book_user_id',
+                'bok.bookUser:id,book_id',
+                'bok.bookUser.book:isbn,name,cover',
+            ])->get();
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -47,6 +47,7 @@ class User extends Authenticatable
     }
 
     public function likes(){
-        return $this->belongsToMany(Bok::class, 'likes', 'user_id', 'bok_id');
+        return $this->belongsToMany(Bok::class, 'reactions', 'user_id', 'bok_id')
+            ->wherePivot('liked', 1);
     }
 }

--- a/database/migrations/2018_12_06_113700_create_reactions_table.php
+++ b/database/migrations/2018_12_06_113700_create_reactions_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateReactionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reactions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('bok_id');
+            $table->boolean('liked')->default(false);
+            $table->boolean('loved')->default(false);
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')->on('users')
+                ->onDelete('cascade');
+            $table->foreign('bok_id')
+                ->references('id')->on('boks')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('reactions');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
         $this->call(BoksTableSeeder::class);
         $this->call(LikesTableSeeder::class);
         $this->call(LovesTableSeeder::class);
+        $this->call(ReactionsTableSeeder::class);
 
         Model::reguard(); //再設定
     }

--- a/database/seeds/ReactionsTableSeeder.php
+++ b/database/seeds/ReactionsTableSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\Reaction;
+
+class ReactionsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $adminUser = App\User::find(1);
+        // bokの良いね数、一般ユーザーからの見え方をテストしたい
+        $normalUser = App\User::find(5);
+        $boks = App\Bok::take(10)->get();
+
+        foreach($boks as $bok) {
+            Reaction::create([
+                'user_id' => $adminUser->id,
+                'bok_id' => $bok->id,
+                'liked' => true,
+                'loved' => true,
+            ]);
+
+            // テスト用として、likeしているものとloveしているデータをランダムに用意している
+            Reaction::create([
+                'user_id' => $normalUser->id,
+                'bok_id' => $bok->id,
+                'liked' => $this->randomBool($bok->id),
+                'loved' => !$this->randomBool($bok->id),
+            ]);
+        }
+    }
+
+    private function randomBool($num) {
+        return $num % 2 == 0;
+    }
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -644,20 +644,70 @@ BOOKBOK　API仕様書
 
         [
             {
-                "id": 1,
-                "body": "bok body",
-                "page_num_begin": 1,
-                "page_num_end": 1,
-                "line_num": 1,
-                "published_at": "2018-11-11 10:30"
+            "id": 1,
+            "user_id": "1",
+            "bok_id": "1",
+            "liked": "1",
+            "loved": "1",
+            "created_at": "2018-12-06 13:56:24",
+            "updated_at": "2018-12-06 13:56:24",
+                "user":{
+                    "id": 1,
+                    "name": "admin",
+                    "avatar": "https://avatars0.githubusercontent.com/u/22770924",
+                    "description": ""
+                },
+                "bok":{
+                    "id": 1,
+                    "user_id": "1",
+                    "body": "カムパネルラが手をあげられないるくなってお父さんのw",
+                    "page_num_begin": "5",
+                    "page_num_end": "5",
+                    "published_at": "2004-07-19 17:14:27",
+                    "book_user_id": "1",
+                    "book_user":{
+                        "id": 1,
+                        "book_id": "9784723597931",
+                        "book":{
+                            "isbn": "9784723597931",
+                            "name": "Labore tempora aspernatur maxime.",
+                            "cover": "http://books.google.com/books/content?id=_42rGAAACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api"
+                        }
+                    }
+                }
             },
             {
-                "id": 2,
-                "body": "bok body",
-                "page_num_begin": 1,
-                "page_num_end": 1,
-                "line_num": 1,
-                "published_at": "2018-11-11 10:30"
+            "id": 2,
+            "user_id": "1",
+            "bok_id": "2",
+            "liked": "1",
+            "loved": "",
+            "created_at": "2018-12-06 13:56:24",
+            "updated_at": "2018-12-06 13:56:24",
+                "user":{
+                    "id": 1,
+                    "name": "admin",
+                    "avatar": "https://avatars0.githubusercontent.com/u/22770924",
+                    "description": ""
+                },
+                "bok":{
+                    "id": 2,
+                    "user_id": "1",
+                    "body": "カムパネルラが手をあげられないるくなってお父さんのw",
+                    "page_num_begin": "20",
+                    "page_num_end": "25",
+                    "published_at": "2004-07-19 17:14:27",
+                    "book_user_id": "2",
+                    "book_user":{
+                        "id": 2,
+                        "book_id": "9784723597931",
+                        "book":{
+                            "isbn": "9784723597931",
+                            "name": "Labore tempora aspernatur maxime.",
+                            "cover": "http://books.google.com/books/content?id=_42rGAAACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api"
+                        }
+                    }
+                }
             }
         ]
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,5 +56,5 @@ Route::get('genres/{genre}', 'GenreController@show');
  * Resource: Like
  *
  */
-Route::get('users/{userId}/likes','LikeController@index');
+Route::get('users/{userId}/likes','ReactionController@likes');
 


### PR DESCRIPTION
connect to #144
close #144

# 概要

- LikeのAPI改善
- LikeとLoveを統合したReactionテーブルを作成

# 主な変更点

- ReactionControllerにLiked一覧を返すAPIを追加
- 発行SQLのlogを出すようにした(`storage/logs/laravel-*.log`に出力)
- ReactionのSeeder定義
- api.mdのLiked一覧のレスポンスを更新

