### PR TITLE
認証系APIのレスポンスを整えた

### DIFF
--- a/app/Http/Controllers/AuthenticationController.php
+++ b/app/Http/Controllers/AuthenticationController.php
@@ -35,15 +35,14 @@ class AuthenticationController extends Controller
             null === $user ||
             false === password_verify($request->password, $user->password)
         ) {
-            return response()->json(
-                'Falid to authentication...',
-                422
-            );
+            return response()->json([
+                'message' => 'Falid to authentication...',
+            ], 422);
         }
 
         return response()->json([
-            'token' => $user->createToken(self::TOKEN_NAME)->accessToken
-        ]);
+            'token' => $user->createToken(self::TOKEN_NAME)->accessToken,
+        ], 200);
     }
 
     /**
@@ -61,8 +60,8 @@ class AuthenticationController extends Controller
 
         $token->revoke();
 
-        return response()->json(
-            'You have been successfully logged out!'
-        );
+        return response()->json([
+            'message' => 'You have been successfully logged out!',
+        ], 200);
     }
 }


### PR DESCRIPTION
connect to #152 
close #152 

# 概要
認証系のapiが、メールアドレスが未登録なら「存在しないよ」とかえしパスワードが間違っていたら「パスワードが間違っているよ」と返していたのでその部分を修正。
あとレスポンスがテキストになっていたりしたのでjsonで統一した。

# 主な変更点
- 認証用コントローラのレスポンス部分をjsonに
- ログインのリクエストをバリデーションするように

# 備考
api呼び出しに「Accept: application/json」を指定しなかった場合、認証が必要なapiを未認証状態で叩くとレスポンスがログインページへのリダイレクトとなる。
なのでapi呼び出し時には必ず上のヘッダーを追加する必要がある。(つまりapiのレスポンスは必ずjsonにしなければならない)