### PR TITLE
refactor _booklist_view.scss

### DIFF
--- a/resources/sass/_booklist_view.scss
+++ b/resources/sass/_booklist_view.scss
@@ -15,12 +15,14 @@ pre.book-view-pre{
         text-overflow: ellipsis;
         width: 92px;
         font-size: 12px;
+        overflow: hidden;
     };
     @include mq-pc {
         margin-left: 30px;
         text-overflow: ellipsis;
         width: 130px;
         font-size: 15px;
+        overflow: hidden;
     };
 } 
 


### PR DESCRIPTION
connect to #182 
close #182 

# 概要
画像のところがスクロールできてしまってたのでできないようにする。

# 主な変更点
_booklist_view.scssにoverflow:hiddenを追加

- 追加・変更した箇所


# 画像(あれば)
![image](https://user-images.githubusercontent.com/25961633/49771241-903ae500-fd2b-11e8-8246-27feeeeb465a.png)


# 参考

- 関連issue、request、comment、その他参照
