### PR TITLE
認証が必要なapiに不正トークンでアクセスした際のレスポンスをドキュメントに

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -62,6 +62,12 @@ BOOKBOK　API仕様書
         {
             "message": "You have been successfully logged out!"
         }
+
++ Response 401 (application/json)
+
+        {
+            "message": "Unauthenticated."
+        }
     
 ## Yourself [/api/auth/user]
 
@@ -79,6 +85,12 @@ BOOKBOK　API仕様書
             "updated_at": "2018-10-24 15:53:09",
             "role_id": "1",
             "name": "あいえええ"
+        }
+
++ Response 401 (application/json)
+
+        {
+            "message": "Unauthenticated."
         }
 
 ## Register [/api/auth/register]
@@ -146,6 +158,12 @@ BOOKBOK　API仕様書
             "message": "Verification failed..."
         }
 
++ Response 401 (application/json)
+
+        {
+            "message": "Unauthenticated."
+        }
+
 + Response 403 (application/json)
 
         {
@@ -172,6 +190,12 @@ BOOKBOK　API仕様書
 
         {
             "message": "Your email has been successfully verified!"
+        }
+
++ Response 401 (application/json)
+
+        {
+            "message": "Unauthenticated."
         }
 
 + Response 429 (application/json)

--- a/docs/api.md
+++ b/docs/api.md
@@ -47,7 +47,7 @@ BOOKBOK　API仕様書
             ]
         }
 
-+ Response 422 (text/html)
++ Response 422 (application/json)
 
         {
             "message": "Falid to authentication..."
@@ -57,7 +57,7 @@ BOOKBOK　API仕様書
 
 ### ログアウトする [GET]
 
-+ Response 200 (text/html)
++ Response 200 (application/json)
 
         {
             "message": "You have been successfully logged out!"
@@ -73,7 +73,7 @@ BOOKBOK　API仕様書
 
 ### 認証したユーザーの情報を取得する [GET]
 
-+ Response 200 (text/html)
++ Response 200 (application/json)
 
         {
             "id": 1,


### PR DESCRIPTION
connect to #151 
close #151 

# 概要
apiドキュメント内の認証が必要なauth系apiのレスポンスに、認証失敗時のレスポンスを追加した。

# 主な変更点
- auth系apiのドキュメント更新
- apiドキュメントのレスポンスコンテンツタイプの間違いを修正