### PR TITLE
パスワードリセットapiを追加

### DIFF
--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -3,37 +3,108 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
 use Illuminate\Foundation\Auth\ResetsPasswords;
+use Illuminate\Contracts\Auth\PasswordBroker;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Password;
 
 class ResetPasswordController extends Controller
 {
-    /*
-    |--------------------------------------------------------------------------
-    | Password Reset Controller
-    |--------------------------------------------------------------------------
-    |
-    | This controller is responsible for handling password reset requests
-    | and uses a simple trait to include this behavior. You're free to
-    | explore this trait and override any methods you wish to tweak.
-    |
-    */
-
-    use ResetsPasswords;
-
+    const ERROR_MSG = [
+        PasswordBroker::INVALID_USER     => '',
+        PasswordBroker::INVALID_PASSWORD => '',
+        PasswordBroker::
+    ];
     /**
-     * Where to redirect users after resetting their password.
+     * パスワードリセットメール送信処理
      *
-     * @var string
+     * @param   Request    $request
+     *  リクエスト
+     * 
+     * @return  \Illuminate\Http\Response
      */
-    protected $redirectTo = '/home';
+    public function send(Request $request)
+    {
+        $validator = \Validator::make($request->all(), [
+            'email' => 'required|string|email|max:255',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 400);
+        }
+
+        $response = Password::broker()->sendResetLink(
+            $request->only('email')
+        );
+
+        return response()->json([
+            'message' => 'We successfully sent a mail with a link to the password reset page!',
+        ], 200);
+    }
 
     /**
-     * Create a new controller instance.
+     * パスワードリセット処理
      *
+     * @param   Request    $request
+     *  リクエスト
+     * 
+     * @return  \Illuminate\Http\Response
+     */
+    public function reset(Request $request)
+    {
+        $validator = \Validator::make($request->all(), [
+            'token'    => 'required',
+            'email'    => 'required|email|max:255',
+            'password' => 'required|min:6',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 400);
+        }
+   
+        $response = Password::broker()->reset(
+            $request->only('token', 'email', 'password') + [
+                'password_confirmation' => $request->all()['password'],
+            ],
+            [$this, 'resetPassword']
+        );
+
+        if (Password::PASSWORD_RESET !== $response) {
+            return response()->json([
+                'message' => self::ERROR_MSG[$response] ?? 'Error...',
+            ], 400);
+        }
+        
+        return response()->json([
+            'message' => 'You have successfully changed password!',
+        ], 200);
+    }
+
+    /**
+     * パスワードをリセットする
+     * 
+     * @param   \App\User   $user
+     *  ユーザー
+     * @param   string  $password
+     *  パスワード
+     * 
      * @return void
      */
-    public function __construct()
+    public function resetPassword(\App\User $user, string $password)
     {
-        $this->middleware('guest');
+        $user->password = password_hash($password, PASSWORD_DEFAULT);
+
+        // これは必要ないけど念のため
+        $user->setRememberToken(Str::random(60));
+
+        // アクセストークンをすべて無効化
+        foreach($user->tokens as $token) {
+            $token->revoke();   
+        }
+
+        $user->save();
+
+        event(new PasswordReset($user));
     }
 }

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -16,6 +16,7 @@ class ResetPasswordController extends Controller
         PasswordBroker::INVALID_PASSWORD => '',
         PasswordBroker::
     ];
+
     /**
      * パスワードリセットメール送信処理
      *

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\ResetsPasswords;
 use Illuminate\Contracts\Auth\PasswordBroker;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Auth\Events\PasswordReset;
 
 class ResetPasswordController extends Controller
 {
@@ -64,7 +65,8 @@ class ResetPasswordController extends Controller
             $request->only('token', 'email', 'password') + [
                 'password_confirmation' => $request->all()['password'],
             ],
-            [$this, 'resetPassword']
+             // PasswordBroker::resetがClosureを求めているのでこうしている。
+            \Closure::fromCallable([$this, 'resetPassword'])
         );
 
         if (Password::PASSWORD_RESET !== $response) {

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -13,6 +13,14 @@ use Illuminate\Auth\Events\PasswordReset;
 class ResetPasswordController extends Controller
 {
     /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->middleware('throttle:6,1')->only('send', 'reset');
+    }
+
+    /**
      * パスワードリセットメール送信処理
      *
      * @param   Request    $request

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -11,12 +11,6 @@ use Illuminate\Support\Facades\Password;
 
 class ResetPasswordController extends Controller
 {
-    const ERROR_MSG = [
-        PasswordBroker::INVALID_USER     => '',
-        PasswordBroker::INVALID_PASSWORD => '',
-        PasswordBroker::
-    ];
-
     /**
      * パスワードリセットメール送信処理
      *
@@ -65,6 +59,8 @@ class ResetPasswordController extends Controller
         }
    
         $response = Password::broker()->reset(
+            // ここでpassword_confirmationを追加するのはPasswordBrokerでその値を使うから。
+            // リクエストに含めないのはパスワードの入力チェックはクライアント側でやってもらいたいから。
             $request->only('token', 'email', 'password') + [
                 'password_confirmation' => $request->all()['password'],
             ],
@@ -73,7 +69,7 @@ class ResetPasswordController extends Controller
 
         if (Password::PASSWORD_RESET !== $response) {
             return response()->json([
-                'message' => self::ERROR_MSG[$response] ?? 'Error...',
+                'message' => 'Password reset failure...',
             ], 400);
         }
         

--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class ResetPassword extends Notification
+{
+    // use Queueable;
+
+    /**
+     * @var string
+     */
+    public $token;
+
+    /**
+     * Constructor
+     * 
+     * @param  string  $token
+     *  トークン
+     */
+    public function __construct($token)
+    {
+        $this->token = $token;
+    }
+
+    /**
+     * Get the notification's channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array|string
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Build the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        logger('パスワードリセットメール送信');
+        return (new MailMessage)
+            ->subject(Lang::getFromJson('パスワードリセット'))
+            ->line(Lang::getFromJson('パスワードのリセットが要請されたためこのメールが送信されました。'))
+            ->action(
+                Lang::getFromJson('Reset Password'),
+                route('dummy.auth.password.reset', ['token' => $this->token])
+            )
+            ->line(Lang::getFromJson('もしパスワードのリセットに心当たりがない場合は、何もしないでください。'))
+        ;
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -85,4 +85,12 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         $this->notify(new Notifications\VerifyEmail);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new Notifications\ResetPassword($token));
+    }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -204,6 +204,96 @@ BOOKBOK　API仕様書
             "message": "Too Many Attempts."
         }
 
+## Password Reset Mail Send [/api/auth/password/reset/send]
+
+### パスワードリセットメールを送信する [POST]
+
+`/auth/password/reset?token={token}`へのリンクを記載したメールが送信される。
+
++ Request (application/json)
+
+    + Attributes
+
+        + email (required)
+
+    + Body
+
+            {
+                "email": "example@example.com"
+            }
+
++ Response 200 (application/json)
+
+        {
+            "message": "We successfully sent a mail with a link to the password reset page!"
+        }
+
++ Response 400 (application/json)
+
+        {
+            "email":[
+                "validation.required"
+            ]
+        }
+
++ Response 429 (application/json)
+
+        {
+            "message": "Too Many Attempts."
+        }
+
+## Password Reset [/api/auth/password/reset]
+
+### パスワードをリセットする [POST]
+
++ Request (application/json)
+
+    + Attributes
+
+        + email: user@example.com (required) - パスワードリセット対象ユーザのメールアドレス
+        + password: newpassword (required) - アンパンマン！新しいパスワードよ
+        + token (required) - メールで送られたリンクのクエリについているリセット用トークン
+
+    + Body
+
+            {
+                "email": "example@example.com",
+                "password": "new-password",
+                "token": "5c4bc3f4b0258db9eedce3693dd75f066d76d80e0058db65b027e3143f03e3"
+            }
+
++ Response 200 (application/json)
+
+        {
+            "message": "You have successfully changed password!"
+        }
+
++ Response 400 (application/json)
+
+        {
+            "email":[
+                "validation.required"
+            ],
+            "password":[
+                "validation.required"
+            ],
+            "token":[
+                "validation.required"
+            ]
+        }
+
++ Response 400 (application/json)
+
+        {
+            "message": "Password reset failure..."
+        }
+
++ Response 429 (application/json)
+
+        {
+            "message": "Too Many Attempts."
+        }
+
 # Group USERS
 
 ## Users [/api/users]

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,9 @@ Route::prefix('auth')->namespace('Auth')->name('auth.')->group(function(){
     Route::post('login','LoginController@login')->name('login');
     Route::post('register','RegisterController@register')->name('register');
 
+    Route::post('password/reset/send', 'ResetPasswordController@send')->name('password.reset.send');
+    Route::post('password/reset', 'ResetPasswordController@reset')->name('password.reset');
+
     Route::middleware('auth:api')->group(function () {
         Route::get('email/verify/{id}', 'VerificationController@verify')
             ->name('email.verify')

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,10 @@ Route::get('/auth/email/verify', function () {
     return view('layouts/app');
 })->name('dummy.auth.email.verify');
 
+Route::get('/auth/password/reset', function () {
+    return view('layouts/app');
+})->name('dummy.auth.password.reset');
+
 Route::get('/{url?}', function () {
     return view('layouts/app');
 })->where('url', '(.*)');


### PR DESCRIPTION
connect to #206 
close #206 

# 概要
パスワードリセットを行うapiを追加した

# 主な変更点
- パスワードリセット関連コントローラー追加(メール送信・リセット)
- メール用の通知クラスを作成(App\Userのメソッドオーバーライドで指定)

# 参考
`/api/auth/password/reset/send` -> メール送信 -> `/api/auth/password/reset` -> 完了!