### PR TITLE
Fix isbn modal

### DIFF
--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -65,10 +65,10 @@ class UserBookController extends Controller
 
         // 入力取得
         $isbn = $request->input('isbn');
-        
+
         // ScrapeManagerの生成
         $scrapers = resolve('app.bookInfo.scrapeManager');
-        
+
         // booksテーブルに該当レコードが存在しているか確認する
         $book = Book::where('isbn', $isbn)->first();
         if($book == null){
@@ -118,7 +118,7 @@ class UserBookController extends Controller
                 [],
                 JSON_UNESCAPED_UNICODE);
         }
-        
+
         // user_bookテーブルに挿入する
         $user_book = new UserBook;
         $user_book->user_id = $authId;

--- a/resources/js/components/shared/book/ISBNModal.jsx
+++ b/resources/js/components/shared/book/ISBNModal.jsx
@@ -2,12 +2,12 @@ import React, { Component } from "react";
 import ReactDOM from 'react-dom';
 import { withRouter } from "react-router-dom";
 import { storeISBNToUserBookDirect } from "../../../actions";
+import { getAuthUser, isEmpty } from '../../../utils';
 
 // ファイル下部でwithRouterに食わせているため、名前を特殊にしている
 class ISBNModal_ extends Component {
     // HACK: サーバー側から帰ってきたちゃんとしたメッセージに置き換える。
     static get INVALID_ISBN_LENGTH(){ return '入力されたISBNの形式が間違っています'; }
-    static get NOT_FOUND_ISBN() { return 'お探しのISBNが存在しません'; }
 
     constructor(props) {
         super(props);
@@ -27,24 +27,31 @@ class ISBNModal_ extends Component {
     handleRegisterISBN(e) {
         e.preventDefault();
         if(this.state.isbn.length !== 13 && this.state.isbn.length !== 10) {
-            this.setState({ isInvalid: true, invalidMessage: ISBNModal.INVALID_ISBN_LENGTH });
-            return;
+            return this.setState({ isInvalid: true, invalidMessage: ISBNModal.INVALID_ISBN_LENGTH });
         }
 
-        storeISBNToUserBookDirect(1, this.state.isbn).then(res => {
+        const user = getAuthUser();
+        if(isEmpty(user)) {
+            return this.props.history.push('/login');
+        }
+        storeISBNToUserBookDirect(user.id, this.state.isbn).then(res => {
             if(res.status === 401) {
                 this.setState({ isInvalid: true, invalidMessage: 'ログインが必要です' });
                 throw new Error();
             } else if(!res.ok) {
-                // TODO: ISBN登録でサーバー側から正しいレスポンスが返るようになった時は、レスポンスのメッセージを表示する
-                this.setState({ isInvalid: true, invalidMessage: ISBNModal.NOT_FOUND_ISBN });
+                res.json().then(json => {
+                    this.setState({ isInvalid: true, invalidMessage: json.userMessage });
+                });
                 throw new Error();
             }
             return res.json();
         }).then(res => {
-            $('#ISBNModal').modal('hide'); // hideしないと画面がバグる
             this.props.history.push(`/users/${res.user.id}/user_books/${res.id}`);
-        }).catch(err => {});
+        }).catch(()=>{});
+    }
+
+    componentWillUnmount() {
+        $('#ISBNModal').modal('hide'); // hideしないと画面がバグる
     }
 
     render() {

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -36,6 +36,11 @@ store.subscribe(() => {
     state = store.getState();
 });
 
+// ログイン中のユーザーを取得するヘルパー関数
+export function getAuthUser() {
+    return state.loggedinUser;
+}
+
 
 /**
  * fetch関数を綺麗に扱えるようにするラッパー関数


### PR DESCRIPTION
connect to #295 
close #295 

# 概要

ISBNModalをリッチに

# 主な変更点

- ログイン中ユーザーを取得するヘルパー関数を追加
- ISBNModalの表示エラーをサーバーからのレスポンスを使って表示
- モーダルの非表示をコンポーネントの終了処理として追加