### PR TITLE
ユーザの情報を出す際にメールアドレスは基本的に出さないようにした

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -27,7 +27,7 @@ class User extends Authenticatable implements MustVerifyEmail
      * @var array
      */
     protected $hidden = [
-        'password', 'remember_token', 'email_verified_at',
+        'password', 'remember_token', 'email', 'email_verified_at',
     ];
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -40,17 +40,6 @@ Route::prefix('auth')->namespace('Auth')->name('auth.')->group(function(){
     });
 });
 
-Route::post('/login','Auth\\LoginController@login');
-Route::middleware('auth:api')->group(function () {
-    Route::get('/logout','Auth\\LoginController@logout');
-});
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user()->makeVisible([
-        'email',
-        'email_verified_at',
-    ]);
-});
-
 // test method
 Route::get('/users', function () {
     $users = App\User::all();

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,7 +32,10 @@ Route::prefix('auth')->namespace('Auth')->name('auth.')->group(function(){
 
         Route::get('logout','LoginController@logout')->name('logout');
         Route::get('user', function (Request $request) {
-            return $request->user();
+            return $request->user()->makeVisible([
+                'email',
+                'email_verified_at',
+            ]);
         })->name('user');
     });
 });
@@ -42,7 +45,10 @@ Route::middleware('auth:api')->group(function () {
     Route::get('/logout','Auth\\LoginController@logout');
 });
 Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
+    return $request->user()->makeVisible([
+        'email',
+        'email_verified_at',
+    ]);
 });
 
 // test method


### PR DESCRIPTION
connect to #288 #231 
close #288 
close #231 

# 概要
メールアドレスを他人に見られるのはまずいので、表示しないようにした。

# 主な変更点
- mailをhiddenに追加
- ログイン中のユーザ自身の情報を取得するapiではemail関連の情報を返すように修正
- 修正完了待機のために残していたルート(login, logout, user)を削除