### PR TITLE
User follow info #317

### DIFF
--- a/app/Helpers/AuthHelper.php
+++ b/app/Helpers/AuthHelper.php
@@ -1,0 +1,12 @@
+<?php
+
+if(! function_exists('getAuthIdOrZero')) {
+    function getAuthIdOrZero() {
+        $authId = auth()->guard('api')->id();
+        if($authId === null) {
+            $authId = 0;
+        }
+
+        return $authId;
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -14,7 +14,8 @@ class UserController extends Controller
      */
     public function index()
     {
-        //
+        $users = User::all();
+        return response()->json($users, 200, [], JSON_UNESCAPED_UNICODE);
     }
 
     /**
@@ -25,6 +26,6 @@ class UserController extends Controller
      */
     public function show(User $user)
     {
-        //
+        return response()->json($user, 200, [], JSON_UNESCAPED_UNICODE);
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\User  $user
+     * @return \Illuminate\Http\Response
+     */
+    public function show(User $user)
+    {
+        //
+    }
+}

--- a/app/Providers/HelperServiceProvider.php
+++ b/app/Providers/HelperServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class HelperServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        foreach (glob(app_path() . '/Helpers/*.php') as $fileNmae) {
+            require_once($fileNmae);
+        }
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -145,8 +145,7 @@ class User extends Authenticatable implements MustVerifyEmail
      *   ログインユーザーのID
      */
     public static function withFollowInfo($authId) {
-        return DB::table('users')
-            ->leftJoin('followers', 'users.id', '=', 'followers.user_id')
+        return self::leftJoin('followers', 'users.id', '=', 'followers.user_id')
             ->select('users.id', 'users.name', 'users.avatar', 'users.description', 'users.created_at', 'users.updated_at', 'users.role_id')
             ->selectRaw('(select count(*) from followers where target_id = users.id) as follower_count')
             ->selectRaw('(select count(*) from followers where user_id = users.id) as following_count')

--- a/config/app.php
+++ b/config/app.php
@@ -174,7 +174,7 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
         App\Providers\BookInfoScraperServiceProvider::class,
-
+        App\Providers\HelperServiceProvider::class,
     ],
 
     /*

--- a/docs/api.md
+++ b/docs/api.md
@@ -328,16 +328,17 @@ BOOKBOK　API仕様書
 
         [
             {
-                "id": 1,
-                "name": "bookuser",
-                "avatar": "https://...",
-                "description": "Hi, I'm teaching network at Kobedenshi."
-            },
-            {
-                "id": 2,
-                "name": "bookuser",
-                "avatar": "https://...",
-                "description": "Hi, I'm teaching network at Kobedenshi."
+                "id": "2",
+                "name": "test-staff",
+                "avatar": "https://avatars0.githubusercontent.com/u/22770924",
+                "description": "",
+                "created_at": "2018-11-19 04:58:55",
+                "updated_at": "2018-11-19 04:58:55",
+                "role_id": "5",
+                "follower_count": "3",
+                "following_count": "1",
+                "followingd": "1",
+                "followerd": "1"
             }
         ]
 
@@ -352,12 +353,18 @@ BOOKBOK　API仕様書
 + Response 200 (application/json)
 
         {
-            "id": 1,
-            "name": "user name",
-            "avator": "http://~",
-            "description": "user info"
+            "id": "2",
+            "name": "test-staff",
+            "avatar": "https://avatars0.githubusercontent.com/u/22770924",
+            "description": "",
+            "created_at": "2018-11-19 04:58:55",
+            "updated_at": "2018-11-19 04:58:55",
+            "role_id": "5",
+            "follower_count": "3",
+            "following_count": "1",
+            "followingd": "1",
+            "followerd": "1"
         }
-
 
 # Group BOOKS
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,18 +57,11 @@ Route::get('books', 'BookController@index');
 Route::get('books/{book}', 'BookController@show');
 
 /**
- * Resource: Review
+ * Resource: Genre
  *
  */
-Route::post('user_books/{userBookId}/review', 'ReviewController@store')->middleware('auth:api');
-Route::put('user_books/{userBookId}/review', 'ReviewController@store')->middleware('auth:api');
-
-/**
- * Resource: Bok
- *
- */
-Route::get('user_books/{userBookId}/boks', 'BokController@index');
-Route::post('user_books/{userBookId}/boks', 'BokController@store')->middleware('auth:api');
+Route::get('genres','GenreController@index');
+Route::get('genres/{genre}', 'GenreController@show');
 
 /**
  * Resource: BokFlow
@@ -84,11 +77,18 @@ Route::get('users/{userId}/user_books/{userBookId}', 'UserBookController@show');
 Route::post('users/{userId}/user_books', 'UserBookController@store')->middleware('auth:api');
 
 /**
- * Resource: Genre
+ * Resource: Review
  *
  */
-Route::get('genres','GenreController@index');
-Route::get('genres/{genre}', 'GenreController@show');
+Route::post('user_books/{userBookId}/review', 'ReviewController@store')->middleware('auth:api');
+Route::put('user_books/{userBookId}/review', 'ReviewController@store')->middleware('auth:api');
+
+/**
+ * Resource: Bok
+ *
+ */
+Route::get('user_books/{userBookId}/boks', 'BokController@index');
+Route::post('user_books/{userBookId}/boks', 'BokController@store')->middleware('auth:api');
 
 /**
  * Resource: Reaction

--- a/routes/api.php
+++ b/routes/api.php
@@ -40,14 +40,11 @@ Route::prefix('auth')->namespace('Auth')->name('auth.')->group(function(){
     });
 });
 
-// test method
-Route::get('/users', function () {
-    $users = App\User::all();
-    return $users;
-});
-Route::get('/users/{user}', function (\App\User $user) {
-    return $user;
-});
+/**
+ *  Resource: User
+ */
+Route::get('/users', 'UserController@index');
+Route::get('/users/{user}', 'UserController@show');
 
 /**
  *  Resource: BOOK

--- a/routes/api.php
+++ b/routes/api.php
@@ -44,7 +44,7 @@ Route::prefix('auth')->namespace('Auth')->name('auth.')->group(function(){
  *  Resource: User
  */
 Route::get('/users', 'UserController@index');
-Route::get('/users/{user}', 'UserController@show');
+Route::get('/users/{userId}', 'UserController@show');
 
 /**
  *  Resource: BOOK


### PR DESCRIPTION
connect to #317 
close wait

# 概要


# 主な変更点

- routes/api.phpの一部ルートの順番を入れ替えた(リソースの関係から順番が気持ち悪かったため)
- User系routeをコントローラーに移植
- ユーザー情報にフォロー系情報を追加(ドキュメントも追従)
- ヘルパー関数定義用ServiceProviderを追加
- ログインユーザーのidをSQLで有効な形で取得する処理をヘルパー化(今後の全面置き換えが必要になる)

### ユーザー詳細の例
```
{
"id": "2",
"name": "test-staff",
"avatar": "https://avatars0.githubusercontent.com/u/22770924",
"description": "",
"created_at": "2018-11-19 04:58:55",
"updated_at": "2018-11-19 04:58:55",
"role_id": "5",
"follower_count": "3",
"following_count": "1",
"followingd": "1",
"followerd": "1"
}
```