### PR TITLE
json_decodeのエラーハンドリングを追加したよ

### DIFF
--- a/app/Components/BookInfoScraper/GoogleBooksScraper.php
+++ b/app/Components/BookInfoScraper/GoogleBooksScraper.php
@@ -74,6 +74,10 @@ class GoogleBooksScraper implements ScraperInterface
         // JSON形式にデコード
         $bookInfo = json_decode($response);
 
+        if(JSON_ERROR_NONE !== json_last_error()){
+            return null;
+        }
+
         //レスポンスなければnullを返す
         if( $bookInfo->totalItems === 0) return null;
         $bookInfo = $bookInfo->items[0]->volumeInfo;

--- a/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
+++ b/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
@@ -97,7 +97,17 @@ class NationalDietLibraryScraper implements ScraperInterface
         // item配下にある名前空間'dc'の要素を取得する
         $dcBookInfoXML = $xml->channel->item->children($nameSpaces['dc']);
         // JSONオブジェクトに変換
-        $dcBookInfoJSON = json_decode(json_encode($dcBookInfoXML, true));
+        $jsonText       = json_encode($dcBookInfoXML, true);
+
+        if(false === $jsonText){
+            return null;
+        }
+
+        $dcBookInfoJSON = json_decode($jsonText);
+
+        if(JSON_ERROR_NONE !== json_last_error()){
+            return null;
+        }
 
         // ScrapeManagerにreturnするBookインスタンスの生成と情報の格納
         $book = new Book;

--- a/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
+++ b/app/Components/BookInfoScraper/NationalDietLibraryScraper.php
@@ -97,7 +97,7 @@ class NationalDietLibraryScraper implements ScraperInterface
         // item配下にある名前空間'dc'の要素を取得する
         $dcBookInfoXML = $xml->channel->item->children($nameSpaces['dc']);
         // JSONオブジェクトに変換
-        $jsonText       = json_encode($dcBookInfoXML, true);
+        $jsonText       = json_encode($dcBookInfoXML);
 
         if(false === $jsonText){
             return null;

--- a/app/Components/BookInfoScraper/ScrapeManager.php
+++ b/app/Components/BookInfoScraper/ScrapeManager.php
@@ -49,7 +49,8 @@ class ScrapeManager
                            ->getBody();
 
         $response = json_decode($response);
-        if($response->count === 0){
+
+        if(JSON_ERROR_NONE !== json_last_error() || $response->count === 0){
             return Genre::ELSE_ID;
         }
 


### PR DESCRIPTION
connect to #351 
close #351 

# 概要
json_decode()でエラーが発生した場合でも、そのまま突き進んでいたのでエラーハンドリングを追加した。

# 主な変更点
- json_decodeを使っていた部分(スクレイパー)のjson_decodeの後にエラーハンドリングのための処理を追加
- 国会図書館のスクレイパー内のjson_encodeについてもエラーハンドリングを追加