### PR TITLE
Fix follow component

### DIFF
--- a/resources/js/components/shared/user/FloatUserInfo.jsx
+++ b/resources/js/components/shared/user/FloatUserInfo.jsx
@@ -83,7 +83,7 @@ FloatUserInfo_.propTypes = {
         id: PropTypes.number.isRequired,
         name: PropTypes.string.isRequired,
         avatar: PropTypes.string.isRequired,
-        description: PropTypes.string.isRequired,
+        description: PropTypes.string,
         follower_count: PropTypes.number.isRequired,
         following_count: PropTypes.number.isRequired,
         is_follower: PropTypes.bool.isRequired,

--- a/resources/js/components/shared/user/FloatUserInfo.jsx
+++ b/resources/js/components/shared/user/FloatUserInfo.jsx
@@ -62,7 +62,10 @@ export class FloatUserInfo_ extends Component {
                         <Link to={`/users/${user.id}/followers`} className="m-2">{user.follower_count} フォロワー</Link>
                     </div>
                 </div>
-                <FollowButton followed={this.state.followed} handleClickFollow={this.handleClickFollow} />
+                <FollowButton
+                    userId={user.id}
+                    followed={this.state.followed}
+                    handleClickFollow={this.handleClickFollow} />
 
                 <div className="user-info-accordion mt-2">
                     <label htmlFor="user-info-accordion-check" className="accordion-label text-center mt-2">

--- a/resources/js/components/shared/user/FloatUserInfo.jsx
+++ b/resources/js/components/shared/user/FloatUserInfo.jsx
@@ -58,8 +58,8 @@ export class FloatUserInfo_ extends Component {
                     </div>
 
                     <div className="user-follow-info mt-2">
-                        <Link to={`/users/${user.id}/followers`} className="m-2">{user.following_count} フォロー</Link>
-                        <Link to={`/users/${user.id}/followings`} className="m-2">{user.follower_count} フォロワー</Link>
+                        <Link to={`/users/${user.id}/followings`} className="m-2">{user.following_count} フォロー</Link>
+                        <Link to={`/users/${user.id}/followers`} className="m-2">{user.follower_count} フォロワー</Link>
                     </div>
                 </div>
                 <FollowButton followed={this.state.followed} handleClickFollow={this.handleClickFollow} />

--- a/resources/js/components/shared/user/FollowButton.jsx
+++ b/resources/js/components/shared/user/FollowButton.jsx
@@ -8,14 +8,14 @@ export default class FollowButton extends Component {
     render() {
         // 自分
         if(getAuthUser() && getAuthUser().id == this.props.userId) {
-            return (<button className="btn btn-primary user-follow-btn" disabled>フォローする</button>);
+            return (<button className="btn btn-primary" disabled>フォローする</button>);
         }
 
         if(this.props.followed) {
             return (
                 <button
                     onClick={this.props.handleClickFollow}
-                    className="btn btn-primary user-follow-btn">
+                    className="btn btn-primary">
                     フォロー中
                 </button>
             );
@@ -23,7 +23,7 @@ export default class FollowButton extends Component {
             return (
                 <button
                     onClick={this.props.handleClickFollow}
-                    className="btn btn-outline-primary user-follow-btn">
+                    className="btn btn-outline-primary">
                     フォローする
                 </button>
             );

--- a/resources/js/components/shared/user/FollowButton.jsx
+++ b/resources/js/components/shared/user/FollowButton.jsx
@@ -32,6 +32,7 @@ export default class FollowButton extends Component {
 }
 
 FollowButton.propTypes = {
+    userId: PropTypes.number,
     followed: PropTypes.bool.isRequired,
     handleClickFollow: PropTypes.func.isRequired,
 };

--- a/resources/js/components/shared/user/FollowButton.jsx
+++ b/resources/js/components/shared/user/FollowButton.jsx
@@ -2,9 +2,15 @@ import React, { Component } from "react";
 import PropTypes from 'prop-types';
 
 import { requestFollow } from '../../../actions';
+import { getAuthUser } from '../../../utils';
 
 export default class FollowButton extends Component {
     render() {
+        // 自分
+        if(getAuthUser() && getAuthUser().id == this.props.userId) {
+            return (<button className="btn btn-primary user-follow-btn" disabled>フォローする</button>);
+        }
+
         if(this.props.followed) {
             return (
                 <button

--- a/resources/js/components/shared/user/SimpleUser.jsx
+++ b/resources/js/components/shared/user/SimpleUser.jsx
@@ -10,14 +10,14 @@ class SimpleUser_ extends Component {
     constructor(props) {
         super(props);
 
-        const is_following = this.props.user.is_following ? this.props.users.is_following : false;
+        const is_following = this.props.user.is_following ? this.props.user.is_following : false;
         this.state = { followed: is_following };
         this.handleClickFollow = this.handleClickFollow.bind(this);
     }
 
     // propsの値が変更された時に、stateのfollowedを変更する
     componentWillReceiveProps(nextProps) {
-        const is_following = nextProps.user.is_following ? nextProps.users.is_following : false;
+        const is_following = nextProps.user.is_following ? nextProps.user.is_following : false;
         this.setState({ followed: is_following });
     }
 

--- a/resources/sass/_user_info.scss
+++ b/resources/sass/_user_info.scss
@@ -49,14 +49,6 @@ img.user-info-avatar {
 /* == !accordion == */
 
 
-.user-follow-btn {
-  max-width: 100%;
-
-  @include middle-screen {
-    max-width: 30%;
-  }
-}
-
 .user-follow-info {
   //line-height: 50px;
 }


### PR DESCRIPTION
connect to #397 
close #397 

# 概要

ログイン時にフォロー系ページにアクセスすると発生していたバグを修正
そのたUI修正

# 主な変更点

### FloatUserInfo
-フォロー系ページへのリンクが間違っていたので修正
- ユーザーのdescriptionがnullableになったことを考慮してPropTypesを修正

### FollowButton
- (ログイン済みで)自分のユーザーページだった場合、フォローボタンをdisable

### SimpleUser
- 変数名が間違えていたので修正(84192ed)