### PR TITLE
Link to user#411

### DIFF
--- a/resources/js/components/Bok.jsx
+++ b/resources/js/components/Bok.jsx
@@ -94,7 +94,9 @@ export class Bok extends Component {
                     <div className="bok-area p-2">
                         <div className="d-flex flex-column h-100">
                             <div className="d-flex border-bottom">
-                                <div className="bok-user mr-auto">{userBook.user.name}</div>
+                                <div className="bok-user mr-auto">
+                                    <Link to={`/users/${userBook.user_id}`}>{userBook.user.name}</Link>
+                                </div>
                             </div>
                             <pre className="bok-body mt-2">{bok.body}</pre>
 

--- a/resources/js/components/Bok.jsx
+++ b/resources/js/components/Bok.jsx
@@ -91,7 +91,7 @@ export class Bok extends Component {
                     </div>
 
                     {/* bok ---------------------------------------------------------------- */}
-                    <div className="bok-area p-2">
+                    <div className="bok-area">
                         <div className="d-flex flex-column h-100">
                             <div className="d-flex border-bottom">
                                 <div className="bok-user mr-auto">

--- a/resources/js/components/UserBookDetail/UserDetailBok.jsx
+++ b/resources/js/components/UserBookDetail/UserDetailBok.jsx
@@ -88,7 +88,11 @@ export class UserDetailBok extends Component {
                     {/* bok ---------------------------------------------------------------- */}
                     <div className="w-100">
                         <div className="d-flex flex-column h-100">
-                            <pre className="userd-bok-user border-bottom">{userBook.user.name}</pre>
+                            <pre className="userd-bok-user border-bottom">
+                                <Link to={`/users/${userBook.user_id}`}>
+                                    {userBook.user.name}
+                                </Link>
+                            </pre>
                             <pre className="userd-bok-body mt-2 mr-2">{bok.body}</pre>
 
                             {/* bok-footer */}

--- a/resources/sass/_bok.scss
+++ b/resources/sass/_bok.scss
@@ -1,5 +1,4 @@
 .bok-book-cover-area {
-  padding: 10px 0px 5px;
   width: 25%;
 
   @include normal-pc {
@@ -11,6 +10,7 @@
   width: 64px;
   height: 80px;
   box-shadow: 0 0 3px 2px #bababa;
+  margin-top: 0.3em;
 
   @include normal-pc {
     width: 76px;
@@ -25,10 +25,11 @@
 .bok-area {
   position: relative;
   width: 75%;
+  padding-left: 0.5em;
 
   @include normal-pc {
-    padding: 10px 10px 10px 20px;
     width: 85%;
+    padding-left: 1em;
   }
 }
 


### PR DESCRIPTION
connect to #411 
close #

# 概要
Bokのユーザー名からユーザーページに飛べるようにした

# 主な変更点
- Bokのユーザー名からユーザーページへ遷移
- UserDetailBokのユーザー名からユーザーページへ遷移
- Linkコンポーネントによって崩れたレイアウトを調整

# 画像(あれば)
![sm_bok](https://user-images.githubusercontent.com/30049713/51159963-0dc7b700-18cf-11e9-9563-80c6d7ac580d.png)
![pc_bok](https://user-images.githubusercontent.com/30049713/51160017-49fb1780-18cf-11e9-855b-c8d887df9b6b.png)
