### PR TITLE
HTTPでアクセスしてきたらHTTPSにリダイレクトさせる処理をミドルウェアで対応する#418

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -20,6 +20,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\UnescapeJsonResponse::class,
+        \App\Http\Middleware\ForceHttps::class,
     ];
 
     /**

--- a/app/Http/Middleware/ForceHttps.php
+++ b/app/Http/Middleware/ForceHttps.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class ForceHttps
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+
+        if( config('https.force') === true and
+            (
+                !$request->secure() or
+                (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) and $_SERVER['HTTP_X_FORWARDED_PROTO' === http])
+            )
+        ){
+            return redirect()->secure($request->path());
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/ForceHttpsProvider.php
+++ b/app/Providers/ForceHttpsProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class ForceHttpsProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        if (config('https.force')) {
+            $this->app['url']->forceScheme('https');
+        }
+    }
+
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+
+    }
+}

--- a/config/https.php
+++ b/config/https.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'force' => env('HTTPS', false),
+];


### PR DESCRIPTION
connect to #418
close #418

# 概要
- httpでアクセスしてきた場合、そのまま通過してしまっていたのでhttpsにリダイレクトさせる。

# 主な変更点
- middlewareの作成（App\Http\Middleware\ForceHttps.php）
- 作成したmiddlewareをグローバルミドルウェアとして`Kerenel.php`に登録する
- `config/https.php`に設定を記述
- サーバサイドで生成するURIのスキームをhttpsに強制する

# 注意点
- localで動かす場合はSSL対応していないので、エラーが出る。
  それを考慮して、デフォルトでは`HTTPS=false`にしている。

# やるべきこと
- 本番環境の環境変数の設定：　`HTTPS=true`