### PR TITLE
fix#434

### DIFF
--- a/app/Http/Middleware/ForceHttps.php
+++ b/app/Http/Middleware/ForceHttps.php
@@ -19,7 +19,7 @@ class ForceHttps
         if( config('https.force') === true and
             (
                 !$request->secure() or
-                (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) and $_SERVER['HTTP_X_FORWARDED_PROTO' === http])
+                (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) and $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'http')
             )
         ){
             return redirect()->secure($request->path());


### PR DESCRIPTION
connect to #434
close #434

# 概要
- http => 'http' らへんの修正
- 括弧の位置も微妙におかしかったもよう。しかし、ローカルでは動いていた(@_@)