### PR TITLE
本の必須情報をとれない無能スクレイパーは無視されるように修正

### DIFF
--- a/app/Components/BookInfoScraper/ScrapeManager.php
+++ b/app/Components/BookInfoScraper/ScrapeManager.php
@@ -78,6 +78,16 @@ class ScrapeManager
         foreach ($this->scrapers as $scraper) {
             $book = $scraper->searchByIsbn($isbn);
             if (null !== $book) {
+                if (
+                    '' === $book->name || null === $book->name
+                    || '' === $book->cover || null === $book->cover
+                    || '' === $book->author || null === $book->author
+                ) {
+                    // 本のタイトル・カバー画像・著者名のうちのどれかが正常に取得できなかった場合、
+                    // 次のscraperへ処理をゆだねる。
+                    continue;
+                }
+
                 $book->genre_id = getGenre($isbn);
                 return $book;
             }


### PR DESCRIPTION
connect to #442 
close #442 

# 概要
本の必須情報(タイトル・カバー画像・著者)を取得できていなければ、
次のスクレイパーへ取得処理をゆだねるように修正。

# 主な変更点
- 取得できた情報をチェックして、だめなら次のスクレイパーへ