### PR TITLE
ページをリロードしてもログイン状態を継続する機能の追加

### DIFF
--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -30,6 +30,10 @@ export const requestLogin = (loginUser) => {
     }).then(json => {
         store.dispatch(setAuthToken(json.token));
         store.dispatch(getLoggedinUser());
+
+        if (loginUser.remember && utils.storageAvailable('localStorage')) {
+            localStorage.setItem('token', json.token);
+        }
     });
 }
 
@@ -46,6 +50,10 @@ export const requestLogout = () => dispatch => {
         isParse: false,
     }).then(res => {
         dispatch(removeLoggedinInfo());
+
+        if (utils.storageAvailable('localStorage') && localStorage.getItem('token')) {
+            localStorage.removeItem('token');
+        }
     });
 }
 

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -4,12 +4,19 @@ import { Provider } from 'react-redux';
 
 import { App } from "./components/App";
 import { store } from "./store";
+import { storageAvailable } from "./utils";
+import { setAuthToken, getLoggedinUser } from "./actions";
 
 const view = (
     <Provider store={store}>
         <App />
     </Provider>
 );
+
+if (storageAvailable('localStorage') && localStorage.getItem('token')) {
+    store.dispatch(setAuthToken(localStorage.getItem('token')));
+    store.dispatch(getLoggedinUser());
+}
 
 if (document.getElementById('app')) {
     render(view, document.getElementById('app'));

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -117,7 +117,7 @@ export function wrapAction(actionCreator, callback) {
  * 
  * @see https://developer.mozilla.org/ja/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API
  */
-function storageAvailable(type) {
+export function storageAvailable(type) {
 	try {
 		var storage = window[type],
             x       = '__storage_test__'

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -108,3 +108,36 @@ export function wrapAction(actionCreator, callback) {
     }
 }
 
+/**
+ * ストレージが使用できるか確認する
+ * 
+ * @param string type ストレージタイプ
+ *  ex) localStorage or sessionstorage
+ * @return bool
+ * 
+ * @see https://developer.mozilla.org/ja/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API
+ */
+function storageAvailable(type) {
+	try {
+		var storage = window[type],
+            x       = '__storage_test__'
+        ;
+		storage.setItem(x, x);
+		storage.removeItem(x);
+		return true;
+	} catch (e) {
+        return e instanceof DOMException && (
+            // everything except Firefox
+            e.code === 22 ||
+            // Firefox
+            e.code === 1014 ||
+            // test name field too, because code might not be present
+            // everything except Firefox
+            e.name === 'QuotaExceededError' ||
+            // Firefox
+            e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+            // acknowledge QuotaExceededError only if there's something already stored
+            storage.length !== 0
+        ;
+    }
+}


### PR DESCRIPTION
connect to #181 
close #181

# 概要
認証が終わると取得したトークンをローカルストレージに格納するようにした。
ページ読み込み時にローカルストレージにトークンが存在すれば、それをつかって認証状態を作り出すようになり、ログアウトするとローカルストレージ内のトークンも破棄する。

# 主な変更点
- storeができた時点でローカルストレージにトークンが存在していたら、いい感じのアクションを実行するようになった
- ブラウザがストレージ系をサポートしているか確認する関数を追加
- ログイン・ログアウト時にローカルストレージを操作する処理を追加

# 参考
Chromeならdevツールのapplicationタブからローカルストレージを参照できる。