### PR TITLE
Fix design

### DIFF
--- a/resources/js/components/UserRegister.jsx
+++ b/resources/js/components/UserRegister.jsx
@@ -77,7 +77,7 @@ export class UserRegister extends Component {
                                 </div>
                                 <form onSubmit={this.submitRegister}>
                                     <div className="form-group row">
-                                        <label htmlFor="name" className="col-md-4 col-form-label text-md-right">名前</label>
+                                        <label htmlFor="name" className="col-md-4 col-form-label text-md-right">ニックネーム</label>
 
                                         <div className="col-md-6">
                                             <input id="name"

--- a/resources/sass/_user_info.scss
+++ b/resources/sass/_user_info.scss
@@ -13,7 +13,7 @@ img.user-info-avatar {
   label {
     display: block;
     cursor: pointer;
-    background-color: #CCFFCC;
+    background-color: #b3e2c7;
     transition: background-color 0.3s;
     max-width: 100%;
 
@@ -22,7 +22,7 @@ img.user-info-avatar {
     }
 
     &:hover {
-      background-color: #99FFCC;
+      background-color: #8fe0b2;
     }
   }
 


### PR DESCRIPTION
connect to #
close #

# 概要
項目名と色を変更

# 主な変更点
- 新規登録画面の「氏名」を「ニックネーム」に変更
- ユーザー情報の詳細確認ボタン(？)の色を変更

# 画像(あれば)
![421](https://user-images.githubusercontent.com/30049713/51512794-1da14700-1e4b-11e9-8419-423ed29ac096.png)
通常時
![hover](https://user-images.githubusercontent.com/30049713/51512809-37db2500-1e4b-11e9-92db-a7837d10971c.png)
ホバー時
![no_hover](https://user-images.githubusercontent.com/30049713/51512812-39a4e880-1e4b-11e9-8541-4ac28ba0bf21.png)
