### PR TITLE
Bokを削除するapi実装#469

### DIFF
--- a/app/Http/Controllers/BokController.php
+++ b/app/Http/Controllers/BokController.php
@@ -136,4 +136,38 @@ class BokController extends Controller
             ->find($bok->id);
         return response()->json($bok, 201);
     }
+
+    /**
+     * Bokを削除するAPI
+     * 
+     * @Request $request
+     *  Laravel組込のリクエストクラス
+     * 
+     * @String $bokId
+     *  BokのID
+     */
+    public function delete(Bok $bok){
+        // 存在しないBokを指定した場合はサーバが自動で404を返す
+
+        $authId = auth()->guard('api')->id();
+        if( $authId != $bok->user_id ){
+            return response()->json(
+                [
+                    'status' => 403,
+                    'userMessage' => '自分以外のBokを削除することはできません。'
+                ],
+                403
+            );
+        }
+
+        $bok->delete();
+
+        return response()->json(
+            [
+                'status' => 200,
+                'userMessage' => '削除しました。'
+            ],
+            200
+        );
+    }
 }

--- a/app/Http/Controllers/BokController.php
+++ b/app/Http/Controllers/BokController.php
@@ -140,11 +140,7 @@ class BokController extends Controller
     /**
      * Bokを削除するAPI
      * 
-     * @Request $request
-     *  Laravel組込のリクエストクラス
-     * 
-     * @String $bokId
-     *  BokのID
+     * @Bok $bok
      */
     public function delete(Bok $bok){
         // 存在しないBokを指定した場合はサーバが自動で404を返す

--- a/docs/api.md
+++ b/docs/api.md
@@ -951,14 +951,14 @@ BOOKBOK　API仕様書
 
         {
             "status": 200,
-            "userMessage": '削除しました。'
+            "userMessage": "削除しました。"
         }
 
 + Response 403 (application/json)
 
         {
             "status": 403,
-            "userMessage": '自分以外のBokを削除することはできません。'
+            "userMessage": "自分以外のBokを削除することはできません。"
         }
 
 # Group BOKFLOW

--- a/docs/api.md
+++ b/docs/api.md
@@ -1021,6 +1021,24 @@ BOOKBOK　API仕様書
             'userMessage' => 'Bokフローの閲覧にはログインが必要です。'
         ]
 
+## Boks [api/boks/{bok}] 
+
+### Delete Bok[DELETE]
+
++ Response 200 (application/json)
+
+        {
+            'status' => 200,
+            'userMessage' => '削除しました。'
+        }
+
++ Response 403 (application/json)
+
+        {
+            'status' =>403,
+            'userMessage' => '自分以外のBokを削除することはできません。'
+        }
+
 # Group FOLLOWERS
 
 ## Followers [/api/users/{userId}/followers]

--- a/docs/api.md
+++ b/docs/api.md
@@ -943,6 +943,24 @@ BOOKBOK　API仕様書
             "user_id": 1
         }
 
+## Boks [api/boks/{bok}] 
+
+### Delete Bok[DELETE]
+
++ Response 200 (application/json)
+
+        {
+            "status": 200,
+            "userMessage": '削除しました。'
+        }
+
++ Response 403 (application/json)
+
+        {
+            "status": 403,
+            "userMessage": '自分以外のBokを削除することはできません。'
+        }
+
 # Group BOKFLOW
 
 ## BOKFLOW [api/bok_flow]
@@ -1020,24 +1038,6 @@ BOOKBOK　API仕様書
             'status' => 401,
             'userMessage' => 'Bokフローの閲覧にはログインが必要です。'
         ]
-
-## Boks [api/boks/{bok}] 
-
-### Delete Bok[DELETE]
-
-+ Response 200 (application/json)
-
-        {
-            'status' => 200,
-            'userMessage' => '削除しました。'
-        }
-
-+ Response 403 (application/json)
-
-        {
-            'status' =>403,
-            'userMessage' => '自分以外のBokを削除することはできません。'
-        }
 
 # Group FOLLOWERS
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -84,7 +84,7 @@ Route::put('user_books/{userBook}/review', 'ReviewController@store')->middleware
  */
 Route::get('user_books/{userBookId}/boks', 'BokController@index');
 Route::post('user_books/{userBook}/boks', 'BokController@store')->middleware('auth:api');
-Route::delete('boks/{bokId}', 'BokController@delete')->middleware('auth:api');
+Route::delete('boks/{bok}', 'BokController@delete')->middleware('auth:api');
 
 /**
  * Resource: Reaction

--- a/routes/api.php
+++ b/routes/api.php
@@ -84,6 +84,7 @@ Route::put('user_books/{userBook}/review', 'ReviewController@store')->middleware
  */
 Route::get('user_books/{userBookId}/boks', 'BokController@index');
 Route::post('user_books/{userBook}/boks', 'BokController@store')->middleware('auth:api');
+Route::delete('boks/{bokId}', 'BokController@delete')->middleware('auth:api');
 
 /**
  * Resource: Reaction


### PR DESCRIPTION
connect to #469 
close #469 

# 概要
- Bokを削除する機能を実装しました(@_@)
- 存在しないBok（id）を指定した場合はサーバが自動で404を返します
※悪意のあるユーザが直接URIを生成してリクエストしない限り、フロントの処理ではまず指定しない