### PR TITLE
Alert view#368

### DIFF
--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -5,7 +5,7 @@ import * as types from "./types";
 /**
  * ==== Alert message ====
  */
-export const setAlertMessage = alertMessage => ({ type: type.SET_ALERT_MESSAGE, alertMessage })
+export const setAlertMessage = (type, message) => ({ type: type.SET_ALERT_MESSAGE, alertView:{type, message} });
 
 /**
  * ==== Top page (time line) ====

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -5,7 +5,7 @@ import * as types from "./types";
 /**
  * ==== Alert message ====
  */
-export const setAlertMessage = (type, message) => ({ type: type.SET_ALERT_MESSAGE, alertView:{type, message} });
+export const setAlertMessage = (alertType, message) => ({ type: types.SET_ALERT_MESSAGE, alertView:{alertType, message} });
 
 /**
  * ==== Top page (time line) ====

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -6,6 +6,7 @@ import * as types from "./types";
  * ==== Alert message ====
  */
 export const setAlertMessage = (alertType, message) => ({ type: types.SET_ALERT_MESSAGE, alertView:{alertType, message} });
+export const deleteAlertMessage = () => ({ type: types.SET_ALERT_MESSAGE, alertView: null })
 
 /**
  * ==== Top page (time line) ====

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -3,6 +3,11 @@ import * as utils from "./utils";
 import * as types from "./types";
 
 /**
+ * ==== Alert message ====
+ */
+export const setAlertMessage = alertMessage => ({ type: type.SET_ALERT_MESSAGE, alertMessage })
+
+/**
  * ==== Top page (time line) ====
  */
 export const setBokFlow = bokFlow => ({ type: types.SET_BOK_FLOW, bokFlow });

--- a/resources/js/components/AlertView.jsx
+++ b/resources/js/components/AlertView.jsx
@@ -3,7 +3,6 @@ import { connect } from "react-redux";
 
 export class AlertView extends Component {
     render(){
-        console.log("alertView : " + this.props.alertView);
         if(!this.props.alertView){
             return null;
         }
@@ -22,7 +21,7 @@ export class AlertView extends Component {
 
         return (
             <div className={alertClass}>
-                {this.props.alertView.message}
+                <div dangerouslySetInnerHTML={this.props.alertView.message} />
                 <button type="button" className="close" data-dismiss="alert" aria-label="閉じる">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/resources/js/components/AlertView.jsx
+++ b/resources/js/components/AlertView.jsx
@@ -9,7 +9,7 @@ export class AlertView extends Component {
         }
 
         let alertClass = "alert-dismissible fade show alert";
-        switch(this.props.alertView.type){
+        switch(this.props.alertView.alertType){
             case "primary"      : alertClass += " alert-primary";   break;  // skyblue
             case "secondary"    : alertClass += " alert-secondary"; break;  // gray
             case "success"      : alertClass += " alert-success";   break;  // green

--- a/resources/js/components/AlertView.jsx
+++ b/resources/js/components/AlertView.jsx
@@ -1,0 +1,29 @@
+import React, { Component } from "react";
+import ReactDOM from 'react-dom';
+import { withRouter } from "react-router-dom";
+import { store } from "../store";
+
+export class AlertView extends Component {
+    render(){
+        let alertClass = "alert-dismissible fade show alert";
+        switch(this.props.alertType){
+            case "primary"      : alertClass += " alert-primary";   break;  // skyblue
+            case "secondary"    : alertClass += " alert-secondary"; break;  // gray
+            case "success"      : alertClass += " alert-success";   break;  // green
+            case "info"         : alertClass += " alert-info";      break;  // blue-green
+            case "warning"      : alertClass += " alert-warning";   break;  // yellow
+            case "danger"       : alertClass += " alert-danger";    break;  // red
+            case "light"        : alertClass += " alert-light";     break;  // white
+            case "dark"         : alertClass += " alert-dark";      break;  // dark-gray
+        }
+
+        return (
+            <div className={alertClass}>
+                {this.props.alertMessage}
+                <button type="button" className="close" data-dismiss="alert" aria-label="閉じる">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+         );
+    }
+}

--- a/resources/js/components/AlertView.jsx
+++ b/resources/js/components/AlertView.jsx
@@ -1,12 +1,15 @@
 import React, { Component } from "react";
-import ReactDOM from 'react-dom';
-import { withRouter } from "react-router-dom";
-import { store } from "../store";
+import { connect } from "react-redux";
 
 export class AlertView extends Component {
     render(){
+        console.log("alertView : " + this.props.alertView);
+        if(!this.props.alertView){
+            return null;
+        }
+
         let alertClass = "alert-dismissible fade show alert";
-        switch(this.props.alertType){
+        switch(this.props.alertView.type){
             case "primary"      : alertClass += " alert-primary";   break;  // skyblue
             case "secondary"    : alertClass += " alert-secondary"; break;  // gray
             case "success"      : alertClass += " alert-success";   break;  // green
@@ -19,7 +22,7 @@ export class AlertView extends Component {
 
         return (
             <div className={alertClass}>
-                {this.props.alertMessage}
+                {this.props.alertView.message}
                 <button type="button" className="close" data-dismiss="alert" aria-label="閉じる">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -27,3 +30,5 @@ export class AlertView extends Component {
          );
     }
 }
+
+export default connect(state => state)(AlertView);

--- a/resources/js/components/App.jsx
+++ b/resources/js/components/App.jsx
@@ -1,44 +1,13 @@
 import React, { Component } from 'react';
 import RouterWithHeader from './RouterWithHeader';
+import { store } from "../store";
+import { AlertView } from "./AlertView";
 
 export class App extends Component {
-    constructor(props){
-        super(props);
-
-        this.alertView = this.alertView.bind(this);
-    }
-
-    alertView(alertType, message){
-        let alertClass = "alert-dismissible fade show alert";
-
-        switch(alertType){
-            case "primary"      : alertClass += " alert-primary";   break;  // skyblue
-            case "secondary"    : alertClass += " alert-secondary"; break;  // gray
-            case "success"      : alertClass += " alert-success";   break;  // green
-            case "info"         : alertClass += " alert-info";      break;  // blue-green
-            case "warning"      : alertClass += " alert-warning";   break;  // yellow
-            case "danger"       : alertClass += " alert-danger";    break;  // red
-            case "light"        : alertClass += " alert-light";     break;  // white
-            case "dark"         : alertClass += " alert-dark";      break;  // dark-gray
-        }
-
-        return (
-                <div className={alertClass}>
-                    {message}
-                    <button type="button" className="close" data-dismiss="alert" aria-label="閉じる">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-               );
-    }
-
     render() {
-        const alertType = "success";
-        const alertMessage = "alert : success";
-
         return (
             <div>
-                {this.alertView(alertType, alertMessage)}
+                <AlertView alertType="success" alertMessage="ねーむーいー"/>
                 <RouterWithHeader />
             </div>
         );

--- a/resources/js/components/App.jsx
+++ b/resources/js/components/App.jsx
@@ -22,15 +22,25 @@ export class App extends Component {
             case "dark"         : alertClass += " alert-dark";      break;  // dark-gray
         }
 
-        return <div className={alertClass}>{message}</div>
+        alertClass += " alert-dismissible fade show";
+
+        return (
+                <div className={alertClass}>
+                    {message}
+                    <button type="button" className="close" data-dismiss="alert" aria-label="閉じる">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+               );
     }
 
     render() {
-        const alertMessage = "Alert test";
+        const alertType = "success";
+        const alertMessage = "alert : success";
 
         return (
             <div>
-                {this.alertView("success" , "alert test : success")}
+                {this.alertView(alertType, alertMessage)}
                 <RouterWithHeader />
             </div>
         );

--- a/resources/js/components/App.jsx
+++ b/resources/js/components/App.jsx
@@ -1,13 +1,14 @@
 import React, { Component } from 'react';
 import RouterWithHeader from './RouterWithHeader';
 import { store } from "../store";
-import { AlertView } from "./AlertView";
+import AlertView from "./AlertView";
 
 export class App extends Component {
     render() {
+        // storeにAlertMessageがあるか確認し、alertType,alertMessageをセットする
         return (
             <div>
-                <AlertView alertType="success" alertMessage="ねーむーいー"/>
+                <AlertView />
                 <RouterWithHeader />
             </div>
         );

--- a/resources/js/components/App.jsx
+++ b/resources/js/components/App.jsx
@@ -9,7 +9,7 @@ export class App extends Component {
     }
 
     alertView(type, message){
-        let alertClass = "alert";
+        let alertClass = "alert-dismissible fade show alert";
 
         switch(type){
             case "primary"      : alertClass += " alert-primary";   break;  // skyblue
@@ -21,8 +21,6 @@ export class App extends Component {
             case "light"        : alertClass += " alert-light";     break;  // white
             case "dark"         : alertClass += " alert-dark";      break;  // dark-gray
         }
-
-        alertClass += " alert-dismissible fade show";
 
         return (
                 <div className={alertClass}>

--- a/resources/js/components/App.jsx
+++ b/resources/js/components/App.jsx
@@ -8,10 +8,10 @@ export class App extends Component {
         this.alertView = this.alertView.bind(this);
     }
 
-    alertView(type, message){
+    alertView(alertType, message){
         let alertClass = "alert-dismissible fade show alert";
 
-        switch(type){
+        switch(alertType){
             case "primary"      : alertClass += " alert-primary";   break;  // skyblue
             case "secondary"    : alertClass += " alert-secondary"; break;  // gray
             case "success"      : alertClass += " alert-success";   break;  // green

--- a/resources/js/components/App.jsx
+++ b/resources/js/components/App.jsx
@@ -2,9 +2,37 @@ import React, { Component } from 'react';
 import RouterWithHeader from './RouterWithHeader';
 
 export class App extends Component {
+    constructor(props){
+        super(props);
+
+        this.alertView = this.alertView.bind(this);
+    }
+
+    alertView(type, message){
+        let alertClass = "alert";
+
+        switch(type){
+            case "primary"      : alertClass += " alert-primary";   break;  // skyblue
+            case "secondary"    : alertClass += " alert-secondary"; break;  // gray
+            case "success"      : alertClass += " alert-success";   break;  // green
+            case "info"         : alertClass += " alert-info";      break;  // blue-green
+            case "warning"      : alertClass += " alert-warning";   break;  // yellow
+            case "danger"       : alertClass += " alert-danger";    break;  // red
+            case "light"        : alertClass += " alert-light";     break;  // white
+            case "dark"         : alertClass += " alert-dark";      break;  // dark-gray
+        }
+
+        return <div className={alertClass}>{message}</div>
+    }
+
     render() {
+        const alertMessage = "Alert test";
+
         return (
-            <RouterWithHeader />
+            <div>
+                {this.alertView("success" , "alert test : success")}
+                <RouterWithHeader />
+            </div>
         );
     }
 }

--- a/resources/js/components/Bok.jsx
+++ b/resources/js/components/Bok.jsx
@@ -1,7 +1,10 @@
 import React, { Component } from "react";
 import { store } from "../store";
 import { Loading } from "./shared/Loading";
-import { requestLike, requestUnLike, requestLove, requestUnLove } from "../actions";
+import { requestLike, requestUnLike,
+         requestLove, requestUnLove,
+         setAlertMessage, deleteAlertMessage} from "../actions";
+import { getAuthUser } from "../utils";
 import { Link } from 'react-router-dom';
 
 export class Bok extends Component {
@@ -38,6 +41,15 @@ export class Bok extends Component {
     }
 
     clickLike(bokId, e){
+        if(!getAuthUser()){
+            store.dispatch(setAlertMessage("warning", {__html: "<div><a href='/login'>ログイン</a>してください</div>"}));
+            setTimeout(
+                () => { store.dispatch(deleteAlertMessage()); },
+                10000
+            );
+            return;
+        }
+
         if(this.state.isLiked){
             this.setState({
                 isLiked: false,
@@ -54,6 +66,15 @@ export class Bok extends Component {
     }
 
     clickLove(bokId, e){
+        if(!getAuthUser()){
+            store.dispatch(setAlertMessage("warning", {__html: "<div><a href='/login'>ログイン</a>してください</div>"}));
+            setTimeout(
+                () => { store.dispatch(deleteAlertMessage()); },
+                10000
+            );
+            return;
+        }
+
         if(this.state.isLoved){
             this.setState({
                 isLoved: false,

--- a/resources/js/components/BokFlow/index.js
+++ b/resources/js/components/BokFlow/index.js
@@ -11,7 +11,13 @@ import BokFlowContent from "./BokFlowContent";
 class BokFlow extends React.Component {
     componentDidMount() {
         if(!getAuthUser()){
-            return store.dispatch(setAlertMessage("warning", {__html: "<Link to='/login'>ログイン</Link>してください"}));
+            store.dispatch(setAlertMessage("warning", {__html: "<Link to='/login'>ログイン</Link>してください"}));
+            setTimeout(
+                () => { store.dispatch(deleteAlertMessage()); },
+                2000
+            );
+
+            return;
         }
         store.dispatch(fetchBokFlow());
     }

--- a/resources/js/components/BokFlow/index.js
+++ b/resources/js/components/BokFlow/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 import { store } from "../../store";
-import { fetchBokFlow } from "../../actions";
+import { fetchBokFlow, setAlertMessage } from "../../actions";
 import { isEmpty, getAuthUser } from "../../utils";
 
 import { Loading } from "../shared/Loading";
@@ -13,6 +13,7 @@ class BokFlow extends React.Component {
         if(!getAuthUser()) return this.props.history.push('/login');
 
         store.dispatch(fetchBokFlow());
+        store.dispatch(setAlertMessage("success", "Here is BokFlow"));
     }
 
     render() {
@@ -27,4 +28,6 @@ class BokFlow extends React.Component {
     }
 }
 
-export default withRouter(connect(state => state)(BokFlow));
+export default withRouter(
+    connect(state => state)(BokFlow)
+);

--- a/resources/js/components/BokFlow/index.js
+++ b/resources/js/components/BokFlow/index.js
@@ -10,15 +10,7 @@ import BokFlowContent from "./BokFlowContent";
 
 class BokFlow extends React.Component {
     componentDidMount() {
-        if(!getAuthUser()){
-            store.dispatch(setAlertMessage("warning", {__html: "<Link to='/login'>ログイン</Link>してください"}));
-            setTimeout(
-                () => { store.dispatch(deleteAlertMessage()); },
-                2000
-            );
-
-            return;
-        }
+        if(!getAuthUser()){ return this.props.history.push("/login"); }
         store.dispatch(fetchBokFlow());
     }
 

--- a/resources/js/components/BokFlow/index.js
+++ b/resources/js/components/BokFlow/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 import { store } from "../../store";
-import { fetchBokFlow, setAlertMessage } from "../../actions";
+import { fetchBokFlow, setAlertMessage, deleteAlertMessage } from "../../actions";
 import { isEmpty, getAuthUser } from "../../utils";
 
 import { Loading } from "../shared/Loading";
@@ -11,10 +11,13 @@ import BokFlowContent from "./BokFlowContent";
 class BokFlow extends React.Component {
     componentDidMount() {
         if(!getAuthUser()){
-            console.log("BokFlow : componentDidMount()");
             return store.dispatch(setAlertMessage("warning", {__html: "<Link to='/login'>ログイン</Link>してください"}));
         }
         store.dispatch(fetchBokFlow());
+    }
+
+    componentWillUnmount() {
+        return store.dispatch(deleteAlertMessage());
     }
 
     render() {

--- a/resources/js/components/BokFlow/index.js
+++ b/resources/js/components/BokFlow/index.js
@@ -10,10 +10,11 @@ import BokFlowContent from "./BokFlowContent";
 
 class BokFlow extends React.Component {
     componentDidMount() {
-        if(!getAuthUser()) return this.props.history.push('/login');
-
+        if(!getAuthUser()){
+            console.log("BokFlow : componentDidMount()");
+            return store.dispatch(setAlertMessage("warning", {__html: "<Link to='/login'>ログイン</Link>してください"}));
+        }
         store.dispatch(fetchBokFlow());
-        store.dispatch(setAlertMessage("success", "Here is BokFlow"));
     }
 
     render() {

--- a/resources/js/components/Home.jsx
+++ b/resources/js/components/Home.jsx
@@ -2,10 +2,6 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { store } from '../store';
 
-clickStartBookBok(alertMessage) {
-    store.dispatch(fetchAlertMessage(alertMessage));
-}
-
 //ホーム画面を表すコンポーネントを定義
 export const Home = () => (
     <div>
@@ -15,7 +11,7 @@ export const Home = () => (
                 <p>本と感想をまとめて管理できるサービスです。</p>
                 <p>他人の書いた感想を読んだり、読書管理をしましょう。</p>
 
-                <div className="register-wrapper mt-5" onClick{(e) => this.clickStartBookBok("BookBokを始める！")}>
+                <div className="register-wrapper mt-5">
                     <Link to="/register" className="btn btn-success">BookBokを始める</Link>
                 </div>
             </div>

--- a/resources/js/components/Home.jsx
+++ b/resources/js/components/Home.jsx
@@ -1,5 +1,10 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
+import { store } from '../store';
+
+clickStartBookBok(alertMessage) {
+    store.dispatch(fetchAlertMessage(alertMessage));
+}
 
 //ホーム画面を表すコンポーネントを定義
 export const Home = () => (
@@ -10,7 +15,7 @@ export const Home = () => (
                 <p>本と感想をまとめて管理できるサービスです。</p>
                 <p>他人の書いた感想を読んだり、読書管理をしましょう。</p>
 
-                <div className="register-wrapper mt-5">
+                <div className="register-wrapper mt-5" onClick{(e) => this.clickStartBookBok("BookBokを始める！")}>
                     <Link to="/register" className="btn btn-success">BookBokを始める</Link>
                 </div>
             </div>

--- a/resources/js/components/UserBookDetail/UserDetailBok.jsx
+++ b/resources/js/components/UserBookDetail/UserDetailBok.jsx
@@ -1,7 +1,10 @@
 import React, { Component } from "react";
 import { store } from "../../store";
 import { Loading } from "../shared/Loading";
-import { requestLike, requestUnLike, requestLove, requestUnLove } from "../../actions";
+import { requestLike, requestUnLike,
+         requestLove, requestUnLove,
+         setAlertMessage, deleteAlertMessage} from "../../actions";
+import { getAuthUser } from "../../utils";
 import { Link } from 'react-router-dom';
 
 export class UserDetailBok extends Component {
@@ -38,6 +41,15 @@ export class UserDetailBok extends Component {
     }
 
     clickLike(bokId, e){
+        if(!getAuthUser()){
+            store.dispatch(setAlertMessage("warning", {__html: "<div><a href='/login'>ログイン</a>してください</div>"}));
+            setTimeout(
+                () => { store.dispatch(deleteAlertMessage()); },
+                10000
+            );
+            return;
+        }
+
         if(this.state.isLiked){
             this.setState({
                 isLiked: false,
@@ -54,6 +66,15 @@ export class UserDetailBok extends Component {
     }
 
     clickLove(bokId, e){
+        if(!getAuthUser()){
+            store.dispatch(setAlertMessage("warning", {__html: "<div><a href='/login'>ログイン</a>してください</div>"}));
+            setTimeout(
+                () => { store.dispatch(deleteAlertMessage()); },
+                10000
+            );
+            return;
+        }
+
         if(this.state.isLoved){
             this.setState({
                 isLoved: false,

--- a/resources/js/components/UserDetail.jsx
+++ b/resources/js/components/UserDetail.jsx
@@ -24,7 +24,6 @@ class UserDetail extends Component {
 
     componentDidMount() {
         store.dispatch(fetchUser(this.props.match.params.id));
-        store.dispatch(setAlertMessage("success", "表示できた！"));
     }
 
     // 更新後のユーザー情報を全てstateにも反映

--- a/resources/js/components/UserDetail.jsx
+++ b/resources/js/components/UserDetail.jsx
@@ -24,6 +24,7 @@ class UserDetail extends Component {
 
     componentDidMount() {
         store.dispatch(fetchUser(this.props.match.params.id));
+        store.dispatch(setAlertMessage("success", "表示できた！"));
     }
 
     // 更新後のユーザー情報を全てstateにも反映
@@ -94,6 +95,7 @@ class UserDetail extends Component {
 
         const currentUser = utils.getAuthUser();
         const me = (currentUser && currentUser.id === user.id);
+
         return (
             <div className="page-content-wrap row">
                 <FloatUserInfo user={user} />

--- a/resources/js/components/shared/book/ISBNModal.jsx
+++ b/resources/js/components/shared/book/ISBNModal.jsx
@@ -1,8 +1,10 @@
 import React, { Component } from "react";
 import ReactDOM from 'react-dom';
 import { withRouter } from "react-router-dom";
-import { storeISBNToUserBookDirect } from "../../../actions";
+import { storeISBNToUserBookDirect,
+         setAlertMessage, deleteAlertMessage} from "../../../actions";
 import { getAuthUser, isEmpty } from '../../../utils';
+import { store } from '../../../store';
 
 // ファイル下部でwithRouterに食わせているため、名前を特殊にしている
 class ISBNModal_ extends Component {
@@ -14,6 +16,7 @@ class ISBNModal_ extends Component {
 
         this.state = { isbn: "", isInvalid: false, invalidMessage: "" };
         this.handleRegisterISBN = this.handleRegisterISBN.bind(this);
+        this.setAlert = this.setAlert.bind(this);
     }
 
     componentDidMount() {
@@ -54,7 +57,20 @@ class ISBNModal_ extends Component {
         $('#ISBNModal').modal('hide'); // hideしないと画面がバグる
     }
 
+    setAlert(e) {
+        store.dispatch(setAlertMessage("warning", {__html: "<div><a href='/login'>ログイン</a>してください</div>"}));
+        setTimeout(
+            () => { store.dispatch(deleteAlertMessage()); },
+            10000
+        );
+        return;
+    }
+
     render() {
+        if(!getAuthUser()){
+            return <button type="button" className="btn btn-success" onClick={this.setAlert}>ISBNから本棚に登録</button>;
+        }
+
         return (
             <div>
                 <button type="button" className="btn btn-success" data-toggle="modal" data-target="#ISBNModal">

--- a/resources/js/components/shared/user/FloatUserInfo.jsx
+++ b/resources/js/components/shared/user/FloatUserInfo.jsx
@@ -1,9 +1,11 @@
 import React, { Component } from "react";
+import { store } from '../../../store';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { withRouter } from "react-router-dom";
 import { getAuthUser, isEmpty } from '../../../utils';
-import { requestFollow, requestUnFollow } from '../../../actions';
+import { requestFollow, requestUnFollow,
+         setAlertMessage, deleteAlertMessage} from '../../../actions';
 import FollowButton from './FollowButton';
 
 /**
@@ -27,11 +29,15 @@ export class FloatUserInfo_ extends Component {
     }
 
     handleClickFollow() {
-        const user = getAuthUser();
-        if(isEmpty(user)) {
-            console.log('ログインが必要です');
-            return this.props.history.push('/login');
+        if(!getAuthUser()){
+            store.dispatch(setAlertMessage("warning", {__html: "<div><a href='/login'>ログイン</a>してください</div>"}));
+            setTimeout(
+                () => { store.dispatch(deleteAlertMessage()); },
+                10000
+            );
+            return;
         }
+
 
         if(this.state.followed) {
             requestUnFollow(user.id, this.props.user.id).then(() => {

--- a/resources/js/reducers.js
+++ b/resources/js/reducers.js
@@ -5,6 +5,9 @@ export function rootReducer(
     action
 ) {
     switch(action.type) {
+        case types.SET_ALERT_MESSAGE:
+            return { ...state, alertMessage: action.alertMessage }
+
         case types.SET_BOK_FLOW:
             return { ...state, bokFlow: action.bokFlow };
 

--- a/resources/js/reducers.js
+++ b/resources/js/reducers.js
@@ -6,7 +6,7 @@ export function rootReducer(
 ) {
     switch(action.type) {
         case types.SET_ALERT_MESSAGE:
-            return { ...state, alertMessage: action.alertMessage }
+            return { ...state, alertView: action.alertView };
 
         case types.SET_BOK_FLOW:
             return { ...state, bokFlow: action.bokFlow };

--- a/resources/js/types.js
+++ b/resources/js/types.js
@@ -1,4 +1,9 @@
 /**
+ * ==== Alert message ====
+ */
+export const SET_ALERT_MESSAGE = "SET_ALERT_MESSAGE";
+
+/**
  * ==== Top page (time line) ====
  */
 export const SET_BOK_FLOW = "SET_BOK_FLOW";


### PR DESCRIPTION
connect to #368 
close #

# 概要
未ログイン時に利用できない部分を使用した際にログインを促す処理を追加

# 主な変更点
- 全画面共通で表示するコンポーネントを追加
- アラートのメッセージをstoreに追加するアクションを追加(`setAlertMessage`)
- storeに追加されたメッセージをnullにするアクションを追加(`deleteAlertMessage`)
- アラートを表示した10秒後にアラートを削除
- 画面遷移時にアラートを削除(ユーザーがアラート表示中に画面遷移したときの対策)

#### ログインしていない時
- Bokフローにアクセス→ログイン画面にリダイレクト
- いいねした時、ログインを促すアラートを表示
- ブクマした時、ログインを促すアラートを表示
- ユーザーページのフォローボタンを押した時、ログインを促すアラートを表示

# 画像(あれば)
![image](https://user-images.githubusercontent.com/30049713/51728456-a5898a00-20b3-11e9-8c6f-b11cd725c491.png)
