### PR TITLE
画像URLを一律1000文字まで格納できるように変更

### DIFF
--- a/app/Http/Controllers/Auth/UserController.php
+++ b/app/Http/Controllers/Auth/UserController.php
@@ -37,7 +37,7 @@ class UserController extends Controller
         $validator = \Validator::make($request->all(), [
             'name'        => 'required|string|regex:/\A[^[:cntrl:]\s]+\z/u|min:1|max:32',
             'description' => 'required|nullable|string|max:1000',
-            'avatar'      => 'required|string|active_url|max:255',
+            'avatar'      => 'required|string|active_url|max:1000',
         ]);
 
         $validator->after(function ($validator) use ($user, $request) {

--- a/database/migrations/2019_01_29_101422_alter_image_url_column_max_length.php
+++ b/database/migrations/2019_01_29_101422_alter_image_url_column_max_length.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AlterImageUrlColumnMaxLength extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('avatar', 1000)->default('')->change();
+        });
+
+        Schema::table('books', function (Blueprint $table) {
+            $table->string('cover', 1000)->change();
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::connection()->getPdo()->exec(
+            'UPDATE users SET avatar = "" WHERE 255 < LENGTH(avatar)'
+        );
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('avatar')->default('')->change();
+        });
+
+        DB::connection()->getPdo()->exec(
+            'UPDATE books SET cover = "https://placehold.jp/cccccc/ffffff/200x284.png?text=not%20found" WHERE 255 < LENGTH(cover)'
+        );
+
+        Schema::table('books', function (Blueprint $table) {
+            $table->string('cover')->change();
+        });
+    }
+}


### PR DESCRIPTION
connect to #493 
close #493 

# 概要
アバターの画像URLが255文字までしか受け付けてくれないという報告があったので、1000文字まで許容するように変更した。

# 主な変更点
- データベースの該当カラムの文字列長変更
- バリデーションでの最大文字列長変更