### PR TITLE
Add isbn list

### DIFF
--- a/app/Http/Controllers/ImportBooksController.php
+++ b/app/Http/Controllers/ImportBooksController.php
@@ -20,7 +20,8 @@ class ImportBooksController extends Controller
     public function store(Request $request){
 
         $validator = \Validator::make($request->all(), [
-            'isbnList' => 'required|string',
+            'isbnList' => 'required|array',
+            'isbnList.*' => 'required|string',
         ]);
 
         if($validator->fails()) {

--- a/app/Http/Controllers/ImportBooksController.php
+++ b/app/Http/Controllers/ImportBooksController.php
@@ -13,12 +13,23 @@ class ImportBooksController extends Controller
     /**
      * 書籍を一括登録するためのエンドポイント
      * カンマ区切りのISBN文字列が送られてくることを期待している
-     * 
+     *
      * @Request $request
      *  リクエスト情報をまとめているLaravel組込クラス
      */
     public function store(Request $request){
-        
+
+        $validator = \Validator::make($request->all(), [
+            'isbnList' => 'required|string',
+        ]);
+
+        if($validator->fails()) {
+            return response()->json([
+                'status' => 400,
+                'userMessage' => $validator->errors()
+            ], 400);
+        }
+
         $authId = auth()->guard('api')->id();
 
         // リクエストデータのの取得
@@ -45,10 +56,10 @@ class ImportBooksController extends Controller
             if(Book::where('isbn', '=', $isbn)->exists()){
 
                 $book = Book::where('isbn', '=', $isbn)->first();
-                
+
                 // App\UserBookに存在しているか確認
                 if(UserBook::where('user_id', '=', $authId)->where('book_id', '=', $book->id)->exists())continue;
-                
+
                 // ユーザの本棚に登録
                 UserBook::create([
                     'user_id' => $authId,

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -189,6 +189,13 @@ export const storeISBNToUserBookDirect = (userId, isbn) => {
     });
 }
 
+export const storeIsbnBulkRegisterDirect = (userId, isbnList) => {
+    return utils.smartFetch('/api/import_books', {
+        body: isbnList,
+        method: 'POST',
+    });
+}
+
 export const setBokToUserBook = bok => ({ type: types.SET_BOK_TO_USER_BOOK, bok });
 export const registerBok = (userBookId, bok) => {
     return utils.smartFetch(`/api/user_books/${userBookId}/boks`, {

--- a/resources/js/components/App/Header.jsx
+++ b/resources/js/components/App/Header.jsx
@@ -26,6 +26,9 @@ class Header extends Component {
                                 <Link className="dropdown-item" to={`/users/${loggedinUser.id}`}>
                                     プロフィール
                                 </Link>
+                                <Link className="dropdown-item" to={'/bulk_regist'}>
+                                    本棚の一括登録
+                                </Link>
                                 <Link className="dropdown-item" to="/logout">
                                     ログアウト
                                 </Link>

--- a/resources/js/components/App/Routes.jsx
+++ b/resources/js/components/App/Routes.jsx
@@ -1,23 +1,31 @@
 import React, { Component } from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
+{/* resource independent page */}
 import Home from '../Home';
-import Login from '../Login';
-import { Logout } from '../Logout';
 import { PrivacyPolicyView } from '../PrivacyPolicyView';
 import { TermsOfServiceView } from '../TermsOfServiceView';
-import { UserRegister } from '../UserRegister';
 
-import BokFlow from '../BokFlow';
-import FollowersView from '../FollowersView';
-import FollowingsView from '../FollowingsView';
-import ConnectedUserDetail from '../UserDetail';
+{/* resource page */}
+import { ConnectedBookDetail, ConnectedUsersView, } from '../../containers';
 import ConnectedBookList from '../BookListView';
+
+{/* require login */}
+import BokFlow from '../BokFlow';
+
+{/* auth page */}
+import { UserRegister } from '../UserRegister';
+import Login from '../Login';
+import { Logout } from '../Logout';
+
+{/* user page */}
+import ConnectedUserDetail from '../UserDetail';
 import UserBookshelf from '../UserBookshelf';
 import UserBookDetail from '../UserBookDetail';
 import LikeBokList from '../LikeBokList';
 import LoveBokList from '../LoveBokList';
-import { ConnectedBookDetail, ConnectedUsersView, } from '../../containers';
+import FollowersView from '../FollowersView';
+import FollowingsView from '../FollowingsView';
 
 
 //react-router-dom
@@ -25,30 +33,38 @@ class Routes extends Component {
     render() {
         return (
             <Switch>
+                {/* resource independent page */}
                 <Route exact path="/" component={ Home } />
                 <Route exact path="/home" component={ Home } />
                 <Route exact path="/privacy" component={ PrivacyPolicyView } />
                 <Route exact path="/terms_of_service" component={ TermsOfServiceView } />
-                <Route exact path="/bok_flow" component={ BokFlow } />
-                <Route exact path="/register" component={ UserRegister } />
-                <Route exact path="/login" component={ Login } />
-                <Route exact path="/logout" component={ Logout } />
-                <Route exact path="/user_register" component={ UserRegister } />
-                <Route exact path="/users/:id" component={ ConnectedUserDetail } />
+
+                {/* resource page */}
                 <Route exact path="/books" component={ ConnectedBookList } />
                 <Route exact path="/books/:id" component={ ConnectedBookDetail } />
+                <Route exact path="/users" component={ ConnectedUsersView } />
+
+                {/* require login */}
+                <Route exact path="/bok_flow" component={ BokFlow } />
+
+                {/* auth page */}
+                <Route exact path="/register" component={ UserRegister } />
+                <Route exact path="/user_register" component={ UserRegister } />
+                <Route exact path="/login" component={ Login } />
+                <Route exact path="/logout" component={ Logout } />
+
+                {/* user page */}
+                <Route exact path="/users/:id" component={ ConnectedUserDetail } />
                 <Route exact path="/users/:id/user_books" component={ UserBookshelf } />
                 <Route exact path="/users/:userId/user_books/:userBookId" component={ UserBookDetail } />
-
                 <Route exact path="/users/:id/likes" component={ LikeBokList } />
                 <Route exact path="/users/:id/loves" component={ LoveBokList } />
                 <Route exact path="/users/:id/followers" component={ FollowersView } />
                 <Route exact path="/users/:id/followings" component={ FollowingsView } />
 
-                <Route exact path="/users" component={ ConnectedUsersView } />
                 <Route exact component={ Home } /> {/* TODO: Replace to 404 page component*/}
             </Switch>
-        )
+        );
     }
 }
 

--- a/resources/js/components/App/Routes.jsx
+++ b/resources/js/components/App/Routes.jsx
@@ -12,6 +12,7 @@ import ConnectedBookList from '../BookListView';
 
 {/* require login */}
 import BokFlow from '../BokFlow';
+import IsbnBulkRegistrationView from '../IsbnBulkRegistrationView';
 
 {/* auth page */}
 import { UserRegister } from '../UserRegister';
@@ -46,6 +47,7 @@ class Routes extends Component {
 
                 {/* require login */}
                 <Route exact path="/bok_flow" component={ BokFlow } />
+                <Route exact path="/bulk_regist" component={ IsbnBulkRegistrationView } />
 
                 {/* auth page */}
                 <Route exact path="/register" component={ UserRegister } />

--- a/resources/js/components/IsbnBulkRegistrationView.jsx
+++ b/resources/js/components/IsbnBulkRegistrationView.jsx
@@ -27,15 +27,18 @@ class IsbnBulkRegistrationView extends Component {
         }
 
         const userId = this.props.loggedinUser.id;
-        storeIsbnBulkRegisterDirect(userId, { isbnList }).then(json => {
-            if(json.status == 400) {
+        storeIsbnBulkRegisterDirect(userId, { isbnList }).then(res => {
+            if(res.status == 400) {
                 this.setState({ invalidMessage: json.userMessage });
-                throw new Error();
+            } else if(res.ok) {
+                return res.json();
             }
-            return res.json();
+            throw new Error(res.statusText);
         }).then(json => {
             this.props.history.push(`/users/${userId}/user_books`);
-        }).catch(()=>{});
+        }).catch(err => {
+            this.setState({ invalidMessage: err.message + ': 登録時にエラーが発生しました。恐れ入りますがフッターの「お問い合わせ」からご連絡ください。' });
+        });
     }
 
     render() {
@@ -48,7 +51,6 @@ class IsbnBulkRegistrationView extends Component {
                             <h1>まとめて登録(ISBN)</h1>
                             <p>本に記載されているISBNを入力することで、簡単に本を自分の本棚に一括登録することができます。<br/>
                             一括登録には若干の時間がかかる場合がありますが、不具合ではありません。</p>
-                            <img src="/images/top.jpg"/>
                         </div>
 
                         <form onSubmit={this.handleSubmitRegister}>

--- a/resources/js/components/IsbnBulkRegistrationView.jsx
+++ b/resources/js/components/IsbnBulkRegistrationView.jsx
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { storeIsbnBulkRegisterDirect } from '../actions';
 import { store } from "../store";
+import { getAuthUser } from "../utils";
 
 
 class IsbnBulkRegistrationView extends Component {
@@ -7,6 +10,32 @@ class IsbnBulkRegistrationView extends Component {
         super(props);
 
         this.state = { text: "", invalidMessage: null };
+        this.handleSubmitRegister = this.handleSubmitRegister.bind(this);
+    }
+
+    componentWillMount() {
+        if(!getAuthUser()) {
+            return this.props.history.push(`/login`);
+        }
+    }
+
+    handleSubmitRegister(e) {
+        e.preventDefault();
+        const isbnList = this.state.text.split("\n");
+        if(isbnList.lenght === 0) {
+            return this.setState({ invalidMessage: "1つ以上のISBNを入力してください" });
+        }
+
+        const userId = this.props.loggedinUser.id;
+        storeIsbnBulkRegisterDirect(userId, { isbnList }).then(json => {
+            if(json.status == 400) {
+                this.setState({ invalidMessage: json.userMessage });
+                throw new Error();
+            }
+            return res.json();
+        }).then(json => {
+            this.props.history.push(`/users/${userId}/user_books`);
+        }).catch(()=>{});
     }
 
     render() {
@@ -19,9 +48,10 @@ class IsbnBulkRegistrationView extends Component {
                             <h1>まとめて登録(ISBN)</h1>
                             <p>本に記載されているISBNを入力することで、簡単に本を自分の本棚に一括登録することができます。<br/>
                             一括登録には若干の時間がかかる場合がありますが、不具合ではありません。</p>
+                            <img src="/images/top.jpg"/>
                         </div>
 
-                        <form>
+                        <form onSubmit={this.handleSubmitRegister}>
                             <div className="form-group">
                                 <label
                                     htmlFor="text">
@@ -57,4 +87,4 @@ class IsbnBulkRegistrationView extends Component {
     }
 }
 
-export default IsbnBulkRegistrationView;
+export default connect(state => state)(IsbnBulkRegistrationView);

--- a/resources/js/components/IsbnBulkRegistrationView.jsx
+++ b/resources/js/components/IsbnBulkRegistrationView.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { storeIsbnBulkRegisterDirect } from '../actions';
 import { store } from "../store";
 import { getAuthUser } from "../utils";
@@ -47,6 +48,7 @@ class IsbnBulkRegistrationView extends Component {
                 <div className="row justify-content-center">
 
                     <div className="col-md-8 main-content p-5">
+                        <Link to={`/users/${this.props.loggedinUser.id}/user_books`} className="btn btn-outline-primary mb-5">本棚へ</Link>
                         <div className="mb-5">
                             <h1>まとめて登録(ISBN)</h1>
                             <p>本に記載されているISBNを入力することで、簡単に本を自分の本棚に一括登録することができます。<br/>

--- a/resources/js/components/IsbnBulkRegistrationView.jsx
+++ b/resources/js/components/IsbnBulkRegistrationView.jsx
@@ -1,20 +1,55 @@
 import React, { Component } from 'react';
-import { fetchBookList } from "../../actions";
-import { store } from "../../store";
+import { store } from "../store";
 
 
 class IsbnBulkRegistrationView extends Component {
     constructor(props) {
         super(props);
 
-        this.state = {  };
+        this.state = { text: "", invalidMessage: null };
     }
 
     render() {
         return(
             <div className="container mt-4">
                 <div className="row justify-content-center">
+
                     <div className="col-md-8 main-content p-5">
+                        <div className="mb-5">
+                            <h1>まとめて登録(ISBN)</h1>
+                            <p>本に記載されているISBNを入力することで、簡単に本を自分の本棚に一括登録することができます。<br/>
+                            一括登録には若干の時間がかかる場合がありますが、不具合ではありません。</p>
+                        </div>
+
+                        <form>
+                            <div className="form-group">
+                                <label
+                                    htmlFor="text">
+                                    ISBN(複数行)
+                                </label>
+
+                                <textarea id="text"
+                                    name="text"
+                                    className={`form-control ${this.state.invalidMessage && "is-invalid"}`}
+                                    value={this.state.text || ''}
+                                    rows="5"
+                                    onChange={(e) => this.setState({ text: e.target.value })}
+                                    required
+                                    autoFocus />
+                                <div className="invalid-feedback">
+                                    {this.state.invalidMessage}
+                                </div>
+                                <small className="text-muted">
+                                    ・isbnを改行区切りで入力してください。<br/>
+                                    ・1つ以上のisbnを入力してください。<br/>
+                                </small>
+                            </div>
+
+                            <div className="form-group row d-flex flex-column align-items-center">
+                                <button type="submit" className="btn btn-success">まとめて登録</button>
+                            </div>
+                        </form>
+
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
connect to #480 
close #480 

# 概要

ISBNを一括登録できる機能を追加(フロント)

# 主な変更点

- ISBN一括登録画面を追加
- ISBN一括登録APIにバリデーションを追加
- Routesコンポーネントをリファクタリング
- ヘッダーにISBN一括登録画面へのリンクを追加(ルーティングも)


# 画像(あれば)

<img width="1680" alt="2019-01-29 20 17 22" src="https://user-images.githubusercontent.com/22770924/51905986-2b843880-2406-11e9-9e1a-871630f2baaf.png">
