### PR TITLE
composer install時に実行するマイグレーション処理を強制実行(非対話)に変更

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
             "@php artisan package:discover --ansi"
         ],
         "post-install-cmd": [
-            "php artisan migrate",
+            "php artisan migrate --force",
             "chmod -R 777 storage",
             "php artisan passport:install"
         ]


### PR DESCRIPTION
connect to #550 
close #550

# 概要
マイグレーション実行時に確認が出るので、それを切った。

# 参考
> #### 実働環境でのマイグレーション強制
> いくつかのマイグレーション操作は破壊的です。つまりデーターを失う可能性があります。実働環境(production)のデータベースに対し、こうしたコマンドが実行されることから保護するために、コマンド実行前に確認のプロンプトが表示されます。コマンド実行時のプロンプトを出さないためには、--forceフラグを指定してください。
[Laravel Doc Migration](https://readouble.com/laravel/5.7/ja/migrations.html)