### PR TITLE
Add email verified page

### DIFF
--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -94,6 +94,19 @@ export const directUserRegister = (userInfo) => {
     });
 };
 
+export const verifyEmail = (href) => {
+    const url = utils.getQueryParam('url', href);
+    return utils.smartFetch(url).then(res => {
+        return res.json();
+    });
+};
+
+export const resendVerifyMail = () => {
+    return utils.smartFetch('/api/auth/email/resend').then(res => {
+        return res.json();
+    });
+}
+
 
 /**
  * ==== Genre resource ====

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -94,8 +94,7 @@ export const directUserRegister = (userInfo) => {
     });
 };
 
-export const verifyEmail = (href) => {
-    const url = utils.getQueryParam('url', href);
+export const verifyEmail = (url) => {
     return utils.smartFetch(url).then(res => {
         return res.json();
     });

--- a/resources/js/actions.js
+++ b/resources/js/actions.js
@@ -101,8 +101,10 @@ export const verifyEmail = (href) => {
     });
 };
 
-export const resendVerifyMail = () => {
-    return utils.smartFetch('/api/auth/email/resend').then(res => {
+export const resendVerifyMail = (email) => {
+    return utils.smartFetch('/api/auth/email/resend', {
+        body: { email },
+    }).then(res => {
         return res.json();
     });
 }

--- a/resources/js/components/App/Routes.jsx
+++ b/resources/js/components/App/Routes.jsx
@@ -18,6 +18,7 @@ import IsbnBulkRegistrationView from '../IsbnBulkRegistrationView';
 import { UserRegister } from '../UserRegister';
 import Login from '../Login';
 import { Logout } from '../Logout';
+import EmailVerify from '../auth/EmailVerify';
 
 {/* user page */}
 import ConnectedUserDetail from '../UserDetail';
@@ -54,6 +55,7 @@ class Routes extends Component {
                 <Route exact path="/user_register" component={ UserRegister } />
                 <Route exact path="/login" component={ Login } />
                 <Route exact path="/logout" component={ Logout } />
+                <Route exact path="/auth/email/verify" component={ EmailVerify } /> // TODO: EmailVerifyに置き換える
 
                 {/* user page */}
                 <Route exact path="/users/:id" component={ ConnectedUserDetail } />

--- a/resources/js/components/auth/EmailVerify.jsx
+++ b/resources/js/components/auth/EmailVerify.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { withRouter, Link } from 'react-router-dom';
 import { store } from "../../store";
-import { successfulStatus, getAuthUser } from '../../utils';
+import { successfulStatus, getAuthUser, getQueryParam } from '../../utils';
 
 import { Loading } from '../shared/Loading';
 import { verifyEmail, resendVerifyMail, setAlertMessage } from '../../actions';
@@ -17,7 +17,8 @@ class EmailVerify extends React.Component {
     }
 
     componentDidMount() {
-        verifyEmail(location.href).then(json => {
+        const url = getQueryParam('url', location.href);
+        verifyEmail(url).then(json => {
             if(successfulStatus(json.status) || !json.status) {
                 store.dispatch(setAlertMessage("success", {__html: json.userMessage}));
                 this.props.history.push('/login');

--- a/resources/js/components/auth/EmailVerify.jsx
+++ b/resources/js/components/auth/EmailVerify.jsx
@@ -1,26 +1,65 @@
 import React from 'react';
-import { withRouter } from 'react-router-dom';
-import { Loading } from '../shared/Loading';
-import { getQueryParam, wrapFetch } from '../../utils';
+import { withRouter, Link } from 'react-router-dom';
+import { store } from "../../store";
+import { successfulStatus } from '../../utils';
 
-export const verifyEmail = (href) => {
-    const url = getQueryParam('url', href);
-    console.log(url);
-    return wrapFetch(url, {
-        isParse: false,
-    });
-};
+import { Loading } from '../shared/Loading';
+import { verifyEmail, resendVerifyMail, setAlertMessage } from '../../actions';
+
 
 class EmailVerify extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = { verified: false };
+        this.handleClickResend = this.handleClickResend.bind(this);
+    }
+
     componentDidMount() {
-        verifyEmail(location.href).then(() => {
-            this.props.history.push('/login');
+        verifyEmail(location.href).then(json => {
+            if(successfulStatus(json.status) || !json.status) {
+                store.dispatch(setAlertMessage("success", {__html: json.userMessage}));
+                this.props.history.push('/login');
+            } else {
+                store.dispatch(setAlertMessage("warning", {__html: json.userMessage}));
+            }
+            this.setState({ verified: true });
+        });
+    }
+
+    handleClickResend() {
+        resendVerifyMail().then(json => {
+            // HACK: 200系で帰るときだけstatusが設定されていない場合が多々あるためこのような記法になっている
+            if(successfulStatus(json.status) || !json.status) {
+                store.dispatch(setAlertMessage("success", {__html: json.userMessage}));
+            } else {
+                store.dispatch(setAlertMessage("warning", {__html: json.userMessage}));
+            }
         });
     }
 
     render() {
+        if(this.state.verified === false) {
+            return <Loading />;
+        }
+
         return (
-            <Loading />
+            <div className="container mt-4">
+                <div className="row justify-content-center">
+                    <div className="col-md-8">
+
+                        <div className="card">
+                            <div className="card-header">メールアドレスを検証してください</div>
+
+                            <div className="card-body">
+                                もし検証メールを確認していない場合、メールが届いていないかご確認ください。<br/>
+                                もう一度メールを送信する場合は<Link to="#" onClick={this.handleClickResend}>こちらをクリックしてください。</Link>
+                            </div>
+                        </div>{/* end card */}
+
+                    </div>
+                </div>
+            </div>
         );
     }
 }

--- a/resources/js/components/auth/EmailVerify.jsx
+++ b/resources/js/components/auth/EmailVerify.jsx
@@ -17,6 +17,8 @@ class EmailVerify extends React.Component {
     }
 
     componentDidMount() {
+        this.setState({ verified: true });
+        return;
         const url = getQueryParam('url', location.href);
         verifyEmail(url).then(json => {
             if(successfulStatus(json.status) || !json.status) {
@@ -72,20 +74,18 @@ class EmailVerify extends React.Component {
                             <div className="card-body">
                                 もし検証メールを確認していない場合、メールが届いていないかご確認ください。<br/>
                                 もう一度メールを送信する場合は
+                                <a role="button"
+                                    className="text-primary"
+                                    onClick={() => this.handleClickResend()} >
+                                    こちらをクリックしてください。
+                                </a>
 
                                 <div className="dropdown">
-                                    <a role="button"
-                                        className="text-primary"
-                                        aria-haspopup="true"
-                                        aria-expanded="false"
-                                        onClick={() => this.handleClickResend()} >
-                                        こちらをクリックしてください。
-                                    </a>
-
                                     <div className={`dropdown-menu p-4 ${this.state.show ? 'show': ''}`}>
                                         <div className="form-group">
                                             <label htmlFor="email">送信先email</label>
-                                            <input name="email"
+                                            <input id="email"
+                                                name="email"
                                                 type="email"
                                                 className="form-control"
                                                 placeholder="email@example.com"
@@ -97,8 +97,8 @@ class EmailVerify extends React.Component {
                                             送信
                                         </button>
                                     </div>
-
                                 </div>
+
                             </div>
                         </div>{/* end card */}
 

--- a/resources/js/components/auth/EmailVerify.jsx
+++ b/resources/js/components/auth/EmailVerify.jsx
@@ -17,8 +17,6 @@ class EmailVerify extends React.Component {
     }
 
     componentDidMount() {
-        this.setState({ verified: true });
-        return;
         const url = getQueryParam('url', location.href);
         verifyEmail(url).then(json => {
             if(successfulStatus(json.status) || !json.status) {

--- a/resources/js/components/auth/EmailVerify.jsx
+++ b/resources/js/components/auth/EmailVerify.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { withRouter } from 'react-router-dom';
+import { Loading } from '../shared/Loading';
+import { getQueryParam, wrapFetch } from '../../utils';
+
+export const verifyEmail = (href) => {
+    const url = getQueryParam('url', href);
+    console.log(url);
+    return wrapFetch(url, {
+        isParse: false,
+    });
+};
+
+class EmailVerify extends React.Component {
+    componentDidMount() {
+        verifyEmail(location.href).then(() => {
+            this.props.history.push('/login');
+        });
+    }
+
+    render() {
+        return (
+            <Loading />
+        );
+    }
+}
+
+export default withRouter(EmailVerify);

--- a/resources/js/components/auth/EmailVerify.jsx
+++ b/resources/js/components/auth/EmailVerify.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { withRouter, Link } from 'react-router-dom';
 import { store } from "../../store";
-import { successfulStatus } from '../../utils';
+import { successfulStatus, getAuthUser } from '../../utils';
 
 import { Loading } from '../shared/Loading';
 import { verifyEmail, resendVerifyMail, setAlertMessage } from '../../actions';
@@ -11,15 +11,16 @@ class EmailVerify extends React.Component {
     constructor(props) {
         super(props);
 
-        this.state = { verified: false };
+        this.state = { verified: false, email: '', show: false };
         this.handleClickResend = this.handleClickResend.bind(this);
+        this.handleChange = this.handleChange.bind(this);
     }
 
     componentDidMount() {
         verifyEmail(location.href).then(json => {
             if(successfulStatus(json.status) || !json.status) {
                 store.dispatch(setAlertMessage("success", {__html: json.userMessage}));
-                this.props.history.push('/login');
+                //this.props.history.push('/login');
             } else {
                 store.dispatch(setAlertMessage("warning", {__html: json.userMessage}));
             }
@@ -27,8 +28,19 @@ class EmailVerify extends React.Component {
         });
     }
 
-    handleClickResend() {
-        resendVerifyMail().then(json => {
+    handleClickResend(email) {
+        let destinationEmail = null;
+        const currentUser = getAuthUser();
+        if(currentUser) {
+            destinationEmail = currentUser.email;
+        } else if(email) {
+            destinationEmail = email;
+        } else {
+            this.setState({ show: true });
+            return;
+        }
+
+        resendVerifyMail(destinationEmail).then(json => {
             // HACK: 200系で帰るときだけstatusが設定されていない場合が多々あるためこのような記法になっている
             if(successfulStatus(json.status) || !json.status) {
                 store.dispatch(setAlertMessage("success", {__html: json.userMessage}));
@@ -36,6 +48,11 @@ class EmailVerify extends React.Component {
                 store.dispatch(setAlertMessage("warning", {__html: json.userMessage}));
             }
         });
+    }
+
+    handleChange(e) {
+        const name = e.target.name;
+        this.setState({ [name]: e.target.value });
     }
 
     render() {
@@ -53,7 +70,34 @@ class EmailVerify extends React.Component {
 
                             <div className="card-body">
                                 もし検証メールを確認していない場合、メールが届いていないかご確認ください。<br/>
-                                もう一度メールを送信する場合は<Link to="#" onClick={this.handleClickResend}>こちらをクリックしてください。</Link>
+                                もう一度メールを送信する場合は
+
+                                <div className="dropdown">
+                                    <a role="button"
+                                        className="text-primary"
+                                        aria-haspopup="true"
+                                        aria-expanded="false"
+                                        onClick={() => this.handleClickResend()} >
+                                        こちらをクリックしてください。
+                                    </a>
+
+                                    <div className={`dropdown-menu p-4 ${this.state.show ? 'show': ''}`}>
+                                        <div className="form-group">
+                                            <label htmlFor="email">送信先email</label>
+                                            <input name="email"
+                                                type="email"
+                                                className="form-control"
+                                                placeholder="email@example.com"
+                                                value={this.state.email}
+                                                onChange={this.handleChange} />
+                                        </div>
+                                        <button className="btn btn-success"
+                                            onClick={() => this.handleClickResend(this.state.email)}>
+                                            送信
+                                        </button>
+                                    </div>
+
+                                </div>
                             </div>
                         </div>{/* end card */}
 

--- a/resources/js/components/auth/EmailVerify.jsx
+++ b/resources/js/components/auth/EmailVerify.jsx
@@ -20,11 +20,11 @@ class EmailVerify extends React.Component {
         verifyEmail(location.href).then(json => {
             if(successfulStatus(json.status) || !json.status) {
                 store.dispatch(setAlertMessage("success", {__html: json.userMessage}));
-                //this.props.history.push('/login');
+                this.props.history.push('/login');
             } else {
                 store.dispatch(setAlertMessage("warning", {__html: json.userMessage}));
+                this.setState({ verified: true });
             }
-            this.setState({ verified: true });
         });
     }
 

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -49,6 +49,17 @@ export function execCopy(text) {
     document.body.removeChild(input);
 }
 
+// URLのクエリパラメータからnameの値を取得する
+export function getQueryParam(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
+
 
 /* ----------------------- */
 import { store } from "./store";


### PR DESCRIPTION
connect to #562 
close #562 

# 概要

Email検証用のページを追加

# 流れ
1. メールからリンクで遷移してくる
2. メール検証のAPIを叩く(クエリパラメータにある `url`を使用して叩く)
3. 検証APIが帰ってきたらtoastで完了メッセージを表示し、ログイン画面に遷移
4. (3で失敗した場合)検証メールの再送信リンクをクリックすると、APIを叩きメールが送信される

# 画像(あれば)

<img width="1680" alt="2019-02-11 0 30 59" src="https://user-images.githubusercontent.com/22770924/52535652-5a9a9280-2d94-11e9-938b-b2874b65994e.png">

<img width="812" alt="2019-02-22 4 20 20" src="https://user-images.githubusercontent.com/22770924/53195565-3de64080-3659-11e9-81a3-3a02731e636f.png">
