### PR TITLE
Update to form request

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -4,6 +4,8 @@ namespace App\Exceptions;
 
 use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class Handler extends ExceptionHandler
 {
@@ -46,6 +48,16 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
+        if ($exception instanceof AuthorizationException) {
+            return response()->json([
+                'userMessage' => [$exception->getMessage()]
+            ], 403);
+        } else if ($exception instanceof ModelNotFoundException) {
+            return response()->json([
+                'userMessage' => [$exception->getMessage()]
+            ], 404);
+        }
+
         return parent::render($request, $exception);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -50,10 +50,12 @@ class Handler extends ExceptionHandler
     {
         if ($exception instanceof AuthorizationException) {
             return response()->json([
+                'status' => 403,
                 'userMessage' => [$exception->getMessage()]
             ], 403);
         } else if ($exception instanceof ModelNotFoundException) {
             return response()->json([
+                'status' => 404,
                 'userMessage' => [$exception->getMessage()]
             ], 404);
         }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -6,6 +6,7 @@ use App\User;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Lcobucci\JWT\Parser;
+use App\Http\Requests\LoginRequest;
 
 class LoginController extends Controller
 {
@@ -14,24 +15,12 @@ class LoginController extends Controller
     /**
      * ログイン処理
      *
-     * @param   Request $request
+     * @param   LoginRequest $request
      *  リクエスト
      *
      * @return  \Illuminate\Http\Response
      */
-    public function login(Request $request) {
-        $validator = \Validator::make($request->all(), [
-            'email'    => 'required|string',
-            'password' => 'required|string',
-        ]);
-
-        if ($validator->fails()) {
-            return response()->json([
-                'status' => 400,
-                'userMessage' => $validator->errors()
-            ], 400);
-        }
-
+    public function login(LoginRequest $request) {
         $user = User::where('email', $request->email)->first();
 
         if (

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -6,32 +6,20 @@ use App\User;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Auth\Events\Registered;
+use App\Http\Requests\UserRequest;
 
 class RegisterController extends Controller
 {
     /**
      * ユーザ登録処理
      *
-     * @param   Request    $request
+     * @param   UserRequest    $request
      *  リクエスト
      *
      * @return  \Illuminate\Http\Response
      */
-    public function register(Request $request)
+    public function register(UserRequest $request)
     {
-        $validator = \Validator::make($request->all(), [
-            'name'     => 'required|string|regex:/\A[^[:cntrl:]\s]+\z/u|min:1|max:32|unique:users',
-            'email'    => 'required|string|email|max:255|unique:users',
-            'password' => 'required|string|min:6',
-        ]);
-
-        if ($validator->fails()) {
-            return response()->json([
-                'status' => 400,
-                'userMessage' => $validator->errors()
-            ], 400);
-        }
-
         $data = $request->all();
         $user = User::create([
             'name'     => $data['name'],

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Auth\Events\PasswordReset;
 use App\Http\Requests\ResetPasswordRequest;
+use App\Http\Requests\ResetPasswordEmailRequest;
 
 class ResetPasswordController extends Controller
 {
@@ -24,24 +25,13 @@ class ResetPasswordController extends Controller
     /**
      * パスワードリセットメール送信処理
      *
-     * @param   Request    $request
+     * @param   ResetPasswordEmailRequest    $request
      *  リクエスト
      *
      * @return  \Illuminate\Http\Response
      */
-    public function send(Request $request)
+    public function send(ResetPasswordEmailRequest $request)
     {
-        $validator = \Validator::make($request->all(), [
-            'email' => 'required|string|email|max:255',
-        ]);
-
-        if ($validator->fails()) {
-            return response()->json([
-                'status' => 400,
-                'userMessage' => $validator->errors()
-            ], 400);
-        }
-
         $response = Password::broker()->sendResetLink(
             $request->only('email')
         );

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Auth\PasswordBroker;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Auth\Events\PasswordReset;
+use App\Http\Requests\ResetPasswordRequest;
 
 class ResetPasswordController extends Controller
 {
@@ -25,7 +26,7 @@ class ResetPasswordController extends Controller
      *
      * @param   Request    $request
      *  リクエスト
-     * 
+     *
      * @return  \Illuminate\Http\Response
      */
     public function send(Request $request)
@@ -53,26 +54,13 @@ class ResetPasswordController extends Controller
     /**
      * パスワードリセット処理
      *
-     * @param   Request    $request
+     * @param   ResetPasswordRequest    $request
      *  リクエスト
-     * 
+     *
      * @return  \Illuminate\Http\Response
      */
-    public function reset(Request $request)
+    public function reset(ResetPasswordRequest $request)
     {
-        $validator = \Validator::make($request->all(), [
-            'token'    => 'required',
-            'email'    => 'required|email|max:255',
-            'password' => 'required|min:6',
-        ]);
-
-        if ($validator->fails()) {
-            return response()->json([
-                'status' => 400,
-                'userMessage' => $validator->errors()
-            ], 400);
-        }
-   
         $response = Password::broker()->reset(
             // ここでpassword_confirmationを追加するのはPasswordBrokerでその値を使うから。
             // リクエストに含めないのはパスワードの入力チェックはクライアント側でやってもらいたいから。
@@ -89,7 +77,7 @@ class ResetPasswordController extends Controller
                 'userMessage' => 'パスワードのリセットに失敗しました。',
             ], 400);
         }
-        
+
         return response()->json([
             'userMessage' => 'パスワードの変更に成功しました。',
         ], 200);
@@ -97,12 +85,12 @@ class ResetPasswordController extends Controller
 
     /**
      * パスワードをリセットする
-     * 
+     *
      * @param   \App\User   $user
      *  ユーザー
      * @param   string  $password
      *  パスワード
-     * 
+     *
      * @return void
      */
     public function resetPassword(\App\User $user, string $password)
@@ -114,7 +102,7 @@ class ResetPasswordController extends Controller
 
         // アクセストークンをすべて無効化
         foreach($user->tokens as $token) {
-            $token->revoke();   
+            $token->revoke();
         }
 
         $user->save();

--- a/app/Http/Controllers/Auth/UserController.php
+++ b/app/Http/Controllers/Auth/UserController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Http\Requests\UserUpdateRequest;
 
 class UserController extends Controller
 {
@@ -26,39 +27,15 @@ class UserController extends Controller
     /**
      * ユーザー情報更新
      *
-     * @param   Request $request
+     * @param   UserUpdateRequest $request
      *  リクエスト
      *
      * @return  \App\User
      */
-    public function update(Request $request)
+    public function update(UserUpdateRequest $request)
     {
-        $user      = $request->user();
-        // ConvertEmptyStringsToNullミドルウェアによって空文字はnullに変換されてしまうためnullを許可
+        // HACK: ConvertEmptyStringsToNullミドルウェアによって空文字はnullに変換されてしまうためnullを許可
         // descriptionとavatarをDBに保存する直前でnullの場合は空文字に変換する
-        $validator = \Validator::make($request->all(), [
-            'name'        => 'required|string|regex:/\A[^[:cntrl:]\s]+\z/u|min:1|max:32',
-            'description' => 'nullable|string|max:1000',
-            'avatar'      => 'nullable|string|active_url|max:1000',
-        ]);
-
-        $validator->after(function ($validator) use ($user, $request) {
-            // このコールバックはバリデーションが成功した場合に追加で呼ばれる
-            $findUser = \App\User::where('name', $request->name)->first();
-
-            if(null !== $findUser && $user->id !== $findUser->id){
-                // 同名ユーザが存在して、認証ユーザと同名ユーザが同一でなければ使用不可
-                $validator->errors()->add('name', '既に使用されています。');
-            }
-        });
-
-        if($validator->fails()) {
-            return response()->json([
-                'status' => 400,
-                'userMessage' => $validator->errors()
-            ], 400);
-        }
-
         $user->name        = $request->name;
         $user->description = $request->description ?? '';
         $user->avatar      = $request->avatar ?? '';

--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Auth\VerifiesEmails;
+use App\Http\Requests\VerifyEmailResendRequest;
 
 class VerificationController extends Controller
 {
@@ -21,12 +22,12 @@ class VerificationController extends Controller
 
     /**
      * メールアドレス検証処理
-     * 
+     *
      * @param   Request    $request
      *  リクエスト
      * @param   User    $user
      *  ルートパラメータから取得したユーザ
-     * 
+     *
      * @return  \Illuminate\Http\Response
      */
     public function verify(Request $request, User $user)
@@ -47,25 +48,14 @@ class VerificationController extends Controller
 
     /**
      * メールアドレス検証メール再送処理
-     * 
+     *
      * @param   Request    $request
      *  リクエスト
-     * 
+     *
      * @return  \Illuminate\Http\Response
      */
-    public function resend(Request $request)
+    public function resend(VerifyEmailResendRequest $request)
     {
-        $validator = \Validator::make($request->all(), [
-            'email' => 'required|string|email|max:255',
-        ]);
-
-        if ($validator->fails()) {
-            return response()->json([
-                'status' => 400,
-                'userMessage' => $validator->errors(),
-            ], 400);
-        }
-
         $user = User::where('email', $request->query('email'))->first();
 
         if(null !== $user && !$user->hasVerifiedEmail()){

--- a/app/Http/Controllers/BokController.php
+++ b/app/Http/Controllers/BokController.php
@@ -65,7 +65,7 @@ class BokController extends Controller
     /**
      * Bokの作成、または更新をするAPI
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Requests\BokRequest  $request
      * @param  \App\UserBook  $userBookId
      * @return \Illuminate\Http\Response
      *   BokのインスタンスJSON

--- a/app/Http/Controllers/BokController.php
+++ b/app/Http/Controllers/BokController.php
@@ -14,6 +14,7 @@ class BokController extends Controller
 {
     public function __construct(){
       $this->middleware('can:create,App\Bok,userBook')->only('store');
+      $this->middleware('can:delete,bok')->only('delete');
     }
 
     /**
@@ -125,19 +126,6 @@ class BokController extends Controller
      * @Bok $bok
      */
     public function delete(Bok $bok){
-        // 存在しないBokを指定した場合はサーバが自動で404を返す
-
-        $authId = auth()->guard('api')->id();
-        if( $authId != $bok->user_id ){
-            return response()->json(
-                [
-                    'status' => 403,
-                    'userMessage' => '自分以外のBokを削除することはできません。'
-                ],
-                403
-            );
-        }
-
         $bok->delete();
 
         return response()->json(

--- a/app/Http/Controllers/BokController.php
+++ b/app/Http/Controllers/BokController.php
@@ -7,6 +7,7 @@ use App\UserBook;
 use App\Bok;
 use App\Reaction;
 use Carbon\Carbon;
+use App\Http\Requests\BokRequest;
 
 class BokController extends Controller
 {
@@ -69,7 +70,7 @@ class BokController extends Controller
      * @return \Illuminate\Http\Response
      *   BokのインスタンスJSON
      */
-    public function store(Request $request, UserBook $userBook)
+    public function store(BokRequest $request, UserBook $userBook)
     {
         $authId = auth()->guard('api')->id();
         if($authId != $userBook->user_id){
@@ -80,21 +81,6 @@ class BokController extends Controller
                 ],
                 403
             );
-        }
-
-        $validator = \Validator::make($request->all(), [
-            'body' => 'required|string|max:2048',
-            'publish' => 'boolean',
-            'page_num_begin' => 'integer',
-            'page_num_end' => 'integer',
-            'line_num' => 'integer',
-        ]);
-
-        if($validator->fails()) {
-            return response()->json([
-                'status' => 400,
-                'userMessage' => $validator->errors()
-            ], 400);
         }
 
         // 公開処理
@@ -139,7 +125,7 @@ class BokController extends Controller
 
     /**
      * Bokを削除するAPI
-     * 
+     *
      * @Bok $bok
      */
     public function delete(Bok $bok){

--- a/app/Http/Controllers/BokController.php
+++ b/app/Http/Controllers/BokController.php
@@ -5,12 +5,17 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\UserBook;
 use App\Bok;
+use App\User;
 use App\Reaction;
 use Carbon\Carbon;
 use App\Http\Requests\BokRequest;
 
 class BokController extends Controller
 {
+    public function __construct(){
+      $this->middleware('can:create,App\Bok,userBook')->only('store');
+    }
+
     /**
      *  BOKSを返すAPI
      *
@@ -66,22 +71,13 @@ class BokController extends Controller
      * Bokの作成、または更新をするAPI
      *
      * @param  \Illuminate\Http\Requests\BokRequest  $request
-     * @param  \App\UserBook  $userBookId
+     * @param  \App\UserBook  $userBook
      * @return \Illuminate\Http\Response
      *   BokのインスタンスJSON
      */
     public function store(BokRequest $request, UserBook $userBook)
     {
         $authId = auth()->guard('api')->id();
-        if($authId != $userBook->user_id){
-            return response()->json(
-                [
-                    'status' => 403,
-                    'userMessage' => '自分以外の本棚に追加することはできません。'
-                ],
-                403
-            );
-        }
 
         // 公開処理
         $publishedAt = null;

--- a/app/Http/Controllers/ImportBooksController.php
+++ b/app/Http/Controllers/ImportBooksController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\UserBook;
 use App\Book;
 use App\Components\BookInfoScraper\ScrapeManager;
+use App\Http\Requests\ImportBookRequest;
 
 class ImportBooksController extends Controller
 {
@@ -17,20 +18,7 @@ class ImportBooksController extends Controller
      * @Request $request
      *  リクエスト情報をまとめているLaravel組込クラス
      */
-    public function store(Request $request){
-
-        $validator = \Validator::make($request->all(), [
-            'isbnList' => 'required|array',
-            'isbnList.*' => 'required|string',
-        ]);
-
-        if($validator->fails()) {
-            return response()->json([
-                'status' => 400,
-                'userMessage' => $validator->errors()
-            ], 400);
-        }
-
+    public function store(ImportBookRequest $request) {
         $authId = auth()->guard('api')->id();
 
         // リクエストデータのの取得

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -7,6 +7,7 @@ use App\UserBook;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
+use App\Http\Requests\ReviewRequest;
 
 class ReviewController extends Controller
 {
@@ -23,22 +24,9 @@ class ReviewController extends Controller
      * @return \Illuminate\Http\Response
      *   ReviewのインスタンスJSON
      */
-    public function store(Request $request, UserBook $userBook)
+    public function store(ReviewRequest $request, UserBook $userBook)
     {
         $authId = auth()->guard('api')->id();
-
-        $validator = \Validator::make($request->all(), [
-            'title'   => 'required|string|max:100',
-            'body'    => 'required|string|max:4048',
-            'publish' => 'boolean',
-        ]);
-
-        if($validator->fails()) {
-            return response()->json([
-                'status' => 400,
-                'userMessage' => $validator->errors()
-            ], 400);
-        }
 
         // 公開処理
         $publishedAt = null;

--- a/app/Http/Controllers/ReviewController.php
+++ b/app/Http/Controllers/ReviewController.php
@@ -10,6 +10,10 @@ use Carbon\Carbon;
 
 class ReviewController extends Controller
 {
+    public function __construct(){
+      $this->middleware('can:create,App\Review,userBook')->only('store');
+    }
+
 
     /**
      * Reviewの作成、または更新をするAPI
@@ -22,15 +26,6 @@ class ReviewController extends Controller
     public function store(Request $request, UserBook $userBook)
     {
         $authId = auth()->guard('api')->id();
-        if($authId != $userBook->user_id){
-            return response()->json(
-                [
-                    'status' => 403,
-                    'userMessage' => '自分以外の本棚に追加することはできません。'
-                ],
-                403
-            );
-        }
 
         $validator = \Validator::make($request->all(), [
             'title'   => 'required|string|max:100',

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -197,6 +197,7 @@ class UserBookController extends Controller
 
     public function __construct(){
       $this->middleware('can:update,userBook')->only('update');
+      $this->middleware('can:delete,userBook')->only('delete');
     }
 
     /**
@@ -258,15 +259,6 @@ class UserBookController extends Controller
 
         // 認可チェック
         $authId = auth()->guard('api')->id();
-        if($authId != $userBook->user_id){
-            return response()->json(
-                [
-                    'status' => 403,
-                    'userMessage' => '自分以外の本を削除することはできません。'
-                ],
-                403
-            );
-        }
 
         $userBook->delete();
 

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -14,6 +14,7 @@ use App\Http\Requests\UserBookUpdateRequest;
 class UserBookController extends Controller
 {
     public function __construct(){
+      $this->middleware('can:create,App\UserBook,user')->only('store');
       $this->middleware('can:update,userBook')->only('update');
       $this->middleware('can:delete,userBook')->only('delete');
     }
@@ -40,27 +41,16 @@ class UserBookController extends Controller
      * ユーザの本棚に本を追加する。
      *
      * @param  \Illuminate\Http\Request  $request
-     * 　POSTメソッドで送られてくる。
-     * 　ボディにはbook_id（本のISBN）が含まれている。
-     * @param $userId
-     * 　usersリソースを一意に特定するためのユーザID。
+     * 　ボディにはISBNが含まれている。
+     * @param $user
      *
      * @return \Illuminate\Http\Response
      * 　JSON形式で本情報をまとめて返す
      */
-    public function store(Request $request, $userId)
+    public function store(Request $request, User $user)
     {
         // 認可チェック
         $authId = auth()->guard('api')->id();
-        if($authId != $userId){
-            return response()->json(
-                [
-                    'status' => 403,
-                    'userMessage' => '自分以外の本棚に追加することはできません。'
-                ],
-                403
-            );
-        }
 
         // 入力取得
         $isbn = $request->input('isbn');

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -9,6 +9,7 @@ use App\Genre;
 use App\Components\BookInfoScraper\ScrapeManager;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\UserBookUpdateRequest;
 
 class UserBookController extends Controller
 {
@@ -209,21 +210,9 @@ class UserBookController extends Controller
      * @return \Illuminate\Http\Response
      * 　JSON形式で本情報をまとめて返す
      */
-    public function update(Request $request, User $user, UserBook $userBook)
+    public function update(UserBookUpdateRequest $request, User $user, UserBook $userBook)
     {
         $authId = auth()->guard('api')->id();
-
-        $validator = \Validator::make($request->all(), [
-            'reading_status' => 'required|string|max:16',
-            'is_spoiler' => 'required|boolean',
-        ]);
-
-        if($validator->fails()) {
-            return response()->json([
-                'status' => 400,
-                'userMessage' => $validator->errors()
-            ], 400);
-        }
 
         $userBook->reading_status = UserBook::READING_STATUS[$request->input('reading_status')];
         $userBook->is_spoiler = $request->input('is_spoiler');

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -194,31 +194,24 @@ class UserBookController extends Controller
         return response()->json($userBook);
     }
 
+    public function __construct(){
+      $this->middleware('can:update,userBook')->only('update');
+    }
+
     /**
      * ユーザの本棚の読了ステータスやネタバレフラグを変更する
      *
      * @param  \Illuminate\Http\Request  $request
      * 　PUTメソッドで送られてくる。
-     * @param $userId
-     * @param $userBookId
+     * @param $user
+     * @param $userBook
      *
      * @return \Illuminate\Http\Response
      * 　JSON形式で本情報をまとめて返す
      */
-    public function update(Request $request, $userId, $userBookId)
+    public function update(Request $request, User $user, UserBook $userBook)
     {
-        // 認可チェック
         $authId = auth()->guard('api')->id();
-        if($authId != $userId){
-            return response()->json(
-                [
-                    'status' => 403,
-                    'userMessage' => '自分以外の本棚を編集することはできません。'
-                ],
-                403
-            );
-        }
-
         $userBook = UserBook::find($userBookId);
         if($userBook == null){
             return response()->json(

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -13,6 +13,11 @@ use App\Http\Requests\UserBookUpdateRequest;
 
 class UserBookController extends Controller
 {
+    public function __construct(){
+      $this->middleware('can:update,userBook')->only('update');
+      $this->middleware('can:delete,userBook')->only('delete');
+    }
+
     /**
      * 特定ユーザの本棚のなかに登録されている本の一覧情報を返す
      *
@@ -193,11 +198,6 @@ class UserBookController extends Controller
             ->find($userBookId);
 
         return response()->json($userBook);
-    }
-
-    public function __construct(){
-      $this->middleware('can:update,userBook')->only('update');
-      $this->middleware('can:delete,userBook')->only('delete');
     }
 
     /**

--- a/app/Http/Controllers/UserBookController.php
+++ b/app/Http/Controllers/UserBookController.php
@@ -212,16 +212,6 @@ class UserBookController extends Controller
     public function update(Request $request, User $user, UserBook $userBook)
     {
         $authId = auth()->guard('api')->id();
-        $userBook = UserBook::find($userBookId);
-        if($userBook == null){
-            return response()->json(
-                [
-                    'status' => 404,
-                    'userMessage' => 'お探しの本は存在しません'
-                ],
-                404
-            );
-        }
 
         $validator = \Validator::make($request->all(), [
             'reading_status' => 'required|string|max:16',
@@ -271,7 +261,7 @@ class UserBookController extends Controller
 
     /**
      * 削除API
-     * 
+     *
      * @UserBook $userBook
      */
     public function delete(UserBook $userBook){

--- a/app/Http/Requests/BokRequest.php
+++ b/app/Http/Requests/BokRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class BokRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'body' => 'required|string|max:2048',
+            'publish' => 'boolean',
+            'page_num_begin' => 'integer',
+            'page_num_end' => 'integer',
+            'line_num' => 'integer',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator) {
+        $res = response()->json([
+            'status' => 400,
+            'userMessage' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Http/Requests/ImportBookRequest.php
+++ b/app/Http/Requests/ImportBookRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class ImportBookRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'isbnList' => 'required|array',
+            'isbnList.*' => 'required|string',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator) {
+        $res = response()->json([
+            'status' => 400,
+            'userMessage' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class LoginRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'email'    => 'required|string',
+            'password' => 'required|string',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator) {
+        $res = response()->json([
+            'status' => 400,
+            'userMessage' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Http/Requests/ResetPasswordEmailRequest.php
+++ b/app/Http/Requests/ResetPasswordEmailRequest.php
@@ -6,7 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exceptions\HttpResponseException;
 
-class ResetPasswordRequest extends FormRequest
+class ResetPasswordEmailRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -26,9 +26,7 @@ class ResetPasswordRequest extends FormRequest
     public function rules()
     {
         return [
-            'token'    => 'required',
-            'email'    => 'required|string|email|max:255',
-            'password' => 'required|min:6',
+            'email' => 'required|string|email|max:255',
         ];
     }
 

--- a/app/Http/Requests/ResetPasswordRequest.php
+++ b/app/Http/Requests/ResetPasswordRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class ResetPasswordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'token'    => 'required',
+            'email'    => 'required|email|max:255',
+            'password' => 'required|min:6',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator) {
+        $res = response()->json([
+            'status' => 400,
+            'userMessage' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Http/Requests/ReviewRequest.php
+++ b/app/Http/Requests/ReviewRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class ReviewRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title'   => 'required|string|max:100',
+            'body'    => 'required|string|max:4048',
+            'publish' => 'boolean',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator) {
+        $res = response()->json([
+            'status' => 400,
+            'userMessage' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Http/Requests/UserBookUpdateRequest.php
+++ b/app/Http/Requests/UserBookUpdateRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class UserBookUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'reading_status' => 'required|string|max:16',
+            'is_spoiler' => 'required|boolean',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'reading_status' => '読書ステータス',
+            'is_spoiler' => 'ネタバレフラグ',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator) {
+        $res = response()->json([
+            'status' => 400,
+            'userMessage' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name'     => 'required|string|regex:/\A[^[:cntrl:]\s]+\z/u|min:1|max:32|unique:users',
+            'email'    => 'required|string|email|max:255|unique:users',
+            'password' => 'required|string|min:6',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator) {
+        $res = response()->json([
+            'status' => 400,
+            'userMessage' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Http/Requests/UserUpdateRequest.php
+++ b/app/Http/Requests/UserUpdateRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class UserUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        // HACK: ConvertEmptyStringsToNullミドルウェアによって空文字はnullに変換されてしまうためnullを許可
+        return [
+            'name'        => 'required|string|regex:/\A[^[:cntrl:]\s]+\z/u|min:1|max:32',
+            'description' => 'nullable|string|max:1000',
+            'avatar'      => 'nullable|string|active_url|max:1000',
+        ];
+    }
+
+    public function withValidator($validator) {
+        $validator->after(function ($validator) {
+            // このコールバックはバリデーションが成功した場合に追加で呼ばれる
+            $findUser = \App\User::where('name', $this->input('name'))->first();
+
+            if(null !== $findUser && $this->user()->id !== $findUser->id){
+                // 同名ユーザが存在して、認証ユーザと同名ユーザが同一でなければ使用不可
+                $validator->errors()->add('name', '既に使用されています。');
+            }
+        });
+    }
+
+    protected function failedValidation(Validator $validator) {
+        $res = response()->json([
+            'status' => 400,
+            'userMessage' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Http/Requests/VerifyEmailResendRequest.php
+++ b/app/Http/Requests/VerifyEmailResendRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class VerifyEmailResendRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'email' => 'required|string|email|max:255',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator) {
+        $res = response()->json([
+            'status' => 400,
+            'userMessage' => $validator->errors(),
+        ], 400);
+
+        throw new HttpResponseException($res);
+    }
+}

--- a/app/Policies/BokPolicy.php
+++ b/app/Policies/BokPolicy.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Bok;
+use App\UserBook;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class BokPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the bok.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Bok  $bok
+     * @return mixed
+     */
+    public function view(User $user, Bok $bok)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create boks.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function create(User $user, UserBook $userBook)
+    {
+        if ($user->id == $userBook->user_id) {
+            return true;
+        }
+        throw new AuthorizationException('自分以外の本棚に追加することはできません。');
+    }
+
+    /**
+     * Determine whether the user can update the bok.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Bok  $bok
+     * @return mixed
+     */
+    public function update(User $user, Bok $bok)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can delete the bok.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Bok  $bok
+     * @return mixed
+     */
+    public function delete(User $user, Bok $bok)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can restore the bok.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Bok  $bok
+     * @return mixed
+     */
+    public function restore(User $user, Bok $bok)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the bok.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Bok  $bok
+     * @return mixed
+     */
+    public function forceDelete(User $user, Bok $bok)
+    {
+        //
+    }
+}

--- a/app/Policies/BokPolicy.php
+++ b/app/Policies/BokPolicy.php
@@ -60,7 +60,10 @@ class BokPolicy
      */
     public function delete(User $user, Bok $bok)
     {
-        //
+        if ($user->id == $bok->user_id) {
+            return true;
+        }
+        throw new AuthorizationException('自分以外のBokを削除することはできません。');
     }
 
     /**

--- a/app/Policies/BokPolicy.php
+++ b/app/Policies/BokPolicy.php
@@ -28,6 +28,7 @@ class BokPolicy
      * Determine whether the user can create boks.
      *
      * @param  \App\User  $user
+     * @param  \App\UserBook  $userBook
      * @return mixed
      */
     public function create(User $user, UserBook $userBook)

--- a/app/Policies/FollowerPolicy.php
+++ b/app/Policies/FollowerPolicy.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Follower;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class FollowerPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the follower.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Follower  $follower
+     * @return mixed
+     */
+    public function view(User $user, Follower $follower)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create followers.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function create(User $user, User $byUser)
+    {
+        if ($user->id == $byUser->id) {
+            return true;
+        }
+        throw new AuthorizationException('リクエスト権限がありません');
+    }
+
+    /**
+     * Determine whether the user can update the follower.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Follower  $follower
+     * @return mixed
+     */
+    public function update(User $user, Follower $follower)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can delete the follower.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Follower  $follower
+     * @return mixed
+     */
+    public function delete(User $user, User $byUser)
+    {
+        if ($user->id == $byUser->id) {
+            return true;
+        }
+        throw new AuthorizationException('リクエスト権限がありません');
+    }
+
+    /**
+     * Determine whether the user can restore the follower.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Follower  $follower
+     * @return mixed
+     */
+    public function restore(User $user, Follower $follower)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the follower.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Follower  $follower
+     * @return mixed
+     */
+    public function forceDelete(User $user, Follower $follower)
+    {
+        //
+    }
+}

--- a/app/Policies/ReviewPolicy.php
+++ b/app/Policies/ReviewPolicy.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\Review;
+use App\UserBook;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class ReviewPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the review.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Review  $review
+     * @return mixed
+     */
+    public function view(User $user, Review $review)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create reviews.
+     *
+     * @param  \App\User  $user
+     * @param  \App\UserBook  $userBook
+     * @return mixed
+     */
+    public function create(User $user, UserBook $userBook)
+    {
+        if ($user->id == $userBook->user_id) {
+            return true;
+        }
+        throw new AuthorizationException('自分以外の本棚に追加することはできません。');
+    }
+
+    /**
+     * Determine whether the user can update the review.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Review  $review
+     * @return mixed
+     */
+    public function update(User $user, Review $review)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can delete the review.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Review  $review
+     * @return mixed
+     */
+    public function delete(User $user, Review $review)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can restore the review.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Review  $review
+     * @return mixed
+     */
+    public function restore(User $user, Review $review)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the review.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Review  $review
+     * @return mixed
+     */
+    public function forceDelete(User $user, Review $review)
+    {
+        //
+    }
+}

--- a/app/Policies/UserBookPolicy.php
+++ b/app/Policies/UserBookPolicy.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Policies;
+
+use App\User;
+use App\UserBook;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class UserBookPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the user book.
+     *
+     * @param  \App\User  $user
+     * @param  \App\UserBook  $userBook
+     * @return mixed
+     */
+    public function view(User $user, UserBook $userBook)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create user books.
+     *
+     * @param  \App\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the user book.
+     *
+     * @param  \App\User  $user
+     * @param  \App\UserBook  $userBook
+     * @return mixed
+     */
+    public function update(User $user, UserBook $userBook)
+    {
+        if ($user->id == $userBook->user_id) {
+            return true;
+        }
+        throw new AuthorizationException('自分以外の本棚を編集することはできません。');
+    }
+
+    /**
+     * Determine whether the user can delete the user book.
+     *
+     * @param  \App\User  $user
+     * @param  \App\UserBook  $userBook
+     * @return mixed
+     */
+    public function delete(User $user, UserBook $userBook)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can restore the user book.
+     *
+     * @param  \App\User  $user
+     * @param  \App\UserBook  $userBook
+     * @return mixed
+     */
+    public function restore(User $user, UserBook $userBook)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the user book.
+     *
+     * @param  \App\User  $user
+     * @param  \App\UserBook  $userBook
+     * @return mixed
+     */
+    public function forceDelete(User $user, UserBook $userBook)
+    {
+        //
+    }
+}

--- a/app/Policies/UserBookPolicy.php
+++ b/app/Policies/UserBookPolicy.php
@@ -29,9 +29,9 @@ class UserBookPolicy
      * @param  \App\User  $user
      * @return mixed
      */
-    public function create(User $user, User $ofUser)
+    public function create(User $user, User $userBookOwner)
     {
-        if ($user->id == $ofUser->id) {
+        if ($user->id == $userBookOwner->id) {
             return true;
         }
         throw new AuthorizationException('自分以外の本棚に追加することはできません。');

--- a/app/Policies/UserBookPolicy.php
+++ b/app/Policies/UserBookPolicy.php
@@ -58,7 +58,10 @@ class UserBookPolicy
      */
     public function delete(User $user, UserBook $userBook)
     {
-        //
+        if ($user->id == $userBook->user_id) {
+            return true;
+        }
+        throw new AuthorizationException('自分以外の本を削除することはできません。');
     }
 
     /**

--- a/app/Policies/UserBookPolicy.php
+++ b/app/Policies/UserBookPolicy.php
@@ -29,9 +29,12 @@ class UserBookPolicy
      * @param  \App\User  $user
      * @return mixed
      */
-    public function create(User $user)
+    public function create(User $user, User $ofUser)
     {
-        //
+        if ($user->id == $ofUser->id) {
+            return true;
+        }
+        throw new AuthorizationException('自分以外の本棚に追加することはできません。');
     }
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -17,7 +17,8 @@ class AuthServiceProvider extends ServiceProvider
         'App\Model' => 'App\Policies\ModelPolicy',
         'App\UserBook' => 'App\Policies\UserBookPolicy',
         'App\Bok' => 'App\Policies\BokPolicy',
-        'App\Review' => 'App\Policies\ReviewPolicy'
+        'App\Review' => 'App\Policies\ReviewPolicy',
+        'App\Follower' => 'App\Policies\FollowerPolicy'
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -15,6 +15,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         'App\Model' => 'App\Policies\ModelPolicy',
+        'App\UserBook' => 'App\Policies\UserBookPolicy'
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,7 +16,8 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         'App\Model' => 'App\Policies\ModelPolicy',
         'App\UserBook' => 'App\Policies\UserBookPolicy',
-        'App\Bok' => 'App\Policies\BokPolicy'
+        'App\Bok' => 'App\Policies\BokPolicy',
+        'App\Review' => 'App\Policies\ReviewPolicy'
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -15,7 +15,8 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         'App\Model' => 'App\Policies\ModelPolicy',
-        'App\UserBook' => 'App\Policies\UserBookPolicy'
+        'App\UserBook' => 'App\Policies\UserBookPolicy',
+        'App\Bok' => 'App\Policies\BokPolicy'
     ];
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,50 +1,54 @@
 {
-    "private": true,
-    "scripts": {
-        "dev": "npm run development",
-        "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "watch": "npm run development -- --watch",
-        "watch-poll": "npm run watch -- --watch-poll",
-        "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "nibble": "eslint-nibble ./",
-        "heroku-postbuild": "npm run production",
-        "precommit": "lint-staged"
-    },
-    "lint-staged": {
-        "*.{js,jsx}": [
-            "eslint ./ --fix",
-            "git add"
-        ]
-    },
-    "devDependencies": {
-        "axios": "^0.18",
-        "babel-eslint": "^10.0.1",
-        "babel-preset-react": "^6.23.0",
-        "bootstrap": "^4.2.1",
-        "cross-env": "^5.1",
-        "eslint": "^5.16.0",
-        "eslint-config-prettier": "^4.1.0",
-        "eslint-nibble": "^5.1.0",
-        "eslint-plugin-prettier": "^3.0.1",
-        "eslint-plugin-react": "^7.12.4",
-        "husky": "^2.1.0",
-        "jquery": "^3.2",
-        "laravel-mix": "^2.1.14",
-        "lint-staged": "^8.1.5",
-        "lodash": "^4.17.5",
-        "popper.js": "^1.14.6",
-        "prettier": "^1.17.0",
-        "react": "^16.7.0",
-        "react-dom": "^16.7.0",
-        "react-redux": "^5.1.1",
-        "redux": "^4.0.1",
-        "redux-devtools-extension": "^2.13.7",
-        "redux-thunk": "^2.3.0"
-    },
-    "dependencies": {
-        "react-infinite-scroller": "^1.2.4",
-        "react-router-dom": "^4.3.1"
+  "private": true,
+  "scripts": {
+    "dev": "npm run development",
+    "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "npm run development -- --watch",
+    "watch-poll": "npm run watch -- --watch-poll",
+    "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "prod": "npm run production",
+    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "nibble": "eslint-nibble ./",
+    "heroku-postbuild": "npm run production"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
     }
+  },
+  "lint-staged": {
+    "*.{js,jsx}": [
+      "eslint ./ --fix",
+      "git add"
+    ]
+  },
+  "devDependencies": {
+    "axios": "^0.18",
+    "babel-eslint": "^10.0.1",
+    "babel-preset-react": "^6.23.0",
+    "bootstrap": "^4.2.1",
+    "cross-env": "^5.1",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^4.1.0",
+    "eslint-nibble": "^5.1.0",
+    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-react": "^7.12.4",
+    "husky": "^2.1.0",
+    "jquery": "^3.2",
+    "laravel-mix": "^2.1.14",
+    "lint-staged": "^8.1.5",
+    "lodash": "^4.17.5",
+    "popper.js": "^1.14.6",
+    "prettier": "^1.17.0",
+    "react": "^16.7.0",
+    "react-dom": "^16.7.0",
+    "react-redux": "^5.1.1",
+    "redux": "^4.0.1",
+    "redux-devtools-extension": "^2.13.7",
+    "redux-thunk": "^2.3.0"
+  },
+  "dependencies": {
+    "react-infinite-scroller": "^1.2.4",
+    "react-router-dom": "^4.3.1"
+  }
 }

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -141,6 +141,8 @@ return [
     */
 
     'attributes' => [
+        'email' => 'Eメール',
+        'password' => 'パスワード',
         'body' => '本文',
         'page_num_begin' => '開始ページ',
         'page_num_end' => '終了ページ',

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -144,6 +144,7 @@ return [
         'name' => '名前',
         'email' => 'Eメール',
         'password' => 'パスワード',
+        'title' => 'タイトル',
         'body' => '本文',
         'page_num_begin' => '開始ページ',
         'page_num_end' => '終了ページ',

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -141,6 +141,7 @@ return [
     */
 
     'attributes' => [
+        'name' => '名前',
         'email' => 'Eメール',
         'password' => 'パスワード',
         'body' => '本文',

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -140,6 +140,11 @@ return [
     |
     */
 
-    'attributes' => [],
+    'attributes' => [
+        'body' => '本文',
+        'page_num_begin' => '開始ページ',
+        'page_num_end' => '終了ページ',
+        'line_num' => '行番号'
+    ],
 
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -102,8 +102,8 @@ Route::delete('boks/{bokId}/loves', 'ReactionController@deleteLove')->middleware
  */
 Route::get('users/{user}/followers','FollowerController@followers');
 Route::get('users/{user}/followings','FollowerController@followings');
-Route::post('users/{userId}/followings','FollowerController@follow')->middleware('auth:api');
-Route::delete('users/{userId}/followings/{targetId}','FollowerController@unfollow')->middleware('auth:api');
+Route::post('users/{user}/followings','FollowerController@follow')->middleware('auth:api');
+Route::delete('users/{user}/followings/{targetUser}','FollowerController@unFollow')->middleware('auth:api');
 
 /**
  * Resource: ?

--- a/routes/api.php
+++ b/routes/api.php
@@ -66,7 +66,7 @@ Route::get('bok_flow', 'BokFlowController@index')->middleware('auth:api');
 Route::get('users/{userId}/user_books','UserBookController@index');
 Route::get('users/{userId}/user_books/{userBookId}', 'UserBookController@show');
 Route::post('users/{userId}/user_books', 'UserBookController@store')->middleware('auth:api');
-Route::put('users/{userId}/user_books/{userBookId}', 'UserBookController@update')->middleware('auth:api');
+Route::put('users/{user}/user_books/{userBook}', 'UserBookController@update')->middleware('auth:api');
 Route::delete('user_books/{userBook}', 'UserBookController@delete')->middleware('auth:api');
 
 /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,7 +65,7 @@ Route::get('bok_flow', 'BokFlowController@index')->middleware('auth:api');
  */
 Route::get('users/{userId}/user_books','UserBookController@index');
 Route::get('users/{userId}/user_books/{userBookId}', 'UserBookController@show');
-Route::post('users/{userId}/user_books', 'UserBookController@store')->middleware('auth:api');
+Route::post('users/{user}/user_books', 'UserBookController@store')->middleware('auth:api');
 Route::put('users/{user}/user_books/{userBook}', 'UserBookController@update')->middleware('auth:api');
 Route::delete('user_books/{userBook}', 'UserBookController@delete')->middleware('auth:api');
 


### PR DESCRIPTION
close #600 

# 概要

通常のValidatorの代わりにFormRequestを使用。
コントローラーで制御していた認可処理をPolicyに移植。

# 主な変更点

- コントローラーに直書きされていたValidationをFormRequestに移植
- コントローラーで制御していた認可処理をPolicyに移植
- 403, 404例外が発生した場合、webページではなくjsonを返すようにHandlerを書き換え
- huskyのWarningを修正(`precommit` -> `pre-commit`)

