### PR TITLE
Add ogp

### DIFF
--- a/app/Http/Controllers/Ssr/UserBookShowController.php
+++ b/app/Http/Controllers/Ssr/UserBookShowController.php
@@ -2,18 +2,33 @@
 
 namespace App\Http\Controllers\Ssr;
 
-use Illuminate\Http\Request;
+use App\Models\UserBook;
+use App\Http\Controllers\Controller;
 
 class UserBookShowController extends Controller
 {
     /**
-     * Handle the incoming request.
+     * UserBookの詳細ページへリンクされた時のOGPを設定するためのハック
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  userId: ユーザの主キー
+     * @param  userBookId: ユーザブックの主キー
      * @return \Illuminate\Http\Response
      */
-    public function __invoke(Request $request)
+    public function __invoke(int $userId, int $userBookId)
     {
-        //
+        $userBook = UserBook::query()
+            ->with([
+                'book:id,name,cover,description',
+                'user:id,name',
+            ])
+            ->find($userBookId);
+
+        $ogpTitle = $userBook->book->name . ':' . $userBook->user->name . 'さんの感想';
+        $ogpDescription = $ogpTitle . '、Boksページです。' . $userBook->book->description;
+        return view('layouts/app', [
+            'ogp_image' => $userBook->book->cover,
+            'ogp_title' => $ogpTitle,
+            'ogp_description' => $ogpDescription,
+        ]);
     }
 }

--- a/app/Http/Controllers/Ssr/UserBookShowController.php
+++ b/app/Http/Controllers/Ssr/UserBookShowController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Ssr;
+
+use Illuminate\Http\Request;
+
+class UserBookShowController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Request $request)
+    {
+        //
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,24 +3,26 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta property="ogp:site_name" content="{{ config('app.name', 'BookBok') }}">
+    <meta property="og:site_name" content="{{ config('app.name', 'BookBok') }}">
     @if (isset($ogp_title))
-        <meta property="ogp:title" content="{{ $ogp_title }}">
+        <meta property="og:title" content="{{ $ogp_title }}">
     @else
-        <meta property="ogp:title" content="{{ config('app.name', 'BookBok') }}">
+        <meta property="og:title" content="{{ config('app.name', 'BookBok') }}">
     @endif
 
     @if (isset($ogp_description))
-        <meta property="ogp:description" content="{{ $ogp_description }}">
+        <meta property="og:description" content="{{ $ogp_description }}">
     @else
-        <meta property="ogp:description" content="読書を今よりも素敵に。本と感想をまとめて管理できるサービスです。">
+        <meta property="og:description" content="読書を今よりも素敵に。本と感想をまとめて管理できるサービスです。">
     @endif
 
     @if (isset($ogp_image))
-        <meta property="ogp:image" content="{{ $ogp_image }}">
+        <meta property="og:image" content="{{ $ogp_image }}">
     @else
-        <meta property="ogp:image" content="">
+        <meta property="og:image" content="">
     @endif
+
+    <meta name="twitter:card" content="summary">
 
     <!-- CSRF Token -->
     <meta name="csrf-token" content="{{ csrf_token() }}">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,7 +21,6 @@
     @else
         <meta property="og:image" content="">
     @endif
-
     <meta name="twitter:card" content="summary">
 
     <!-- CSRF Token -->

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,6 +3,24 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta property="ogp:site_name" content="{{ config('app.name', 'BookBok') }}">
+    @if (isset($ogp_title))
+        <meta property="ogp:title" content="{{ $ogp_title }}">
+    @else
+        <meta property="ogp:title" content="{{ config('app.name', 'BookBok') }}">
+    @endif
+
+    @if (isset($ogp_description))
+        <meta property="ogp:description" content="{{ $ogp_description }}">
+    @else
+        <meta property="ogp:description" content="読書を今よりも素敵に。本と感想をまとめて管理できるサービスです。">
+    @endif
+
+    @if (isset($ogp_image))
+        <meta property="ogp:image" content="{{ $ogp_image }}">
+    @else
+        <meta property="ogp:image" content="">
+    @endif
 
     <!-- CSRF Token -->
     <meta name="csrf-token" content="{{ csrf_token() }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,9 @@ Route::get('/auth/password/reset', function () {
     return view('layouts/app');
 })->name('dummy.auth.password.reset');
 
+Route::get('/users/{userId}/user_books/{userBookId}', 'Ssr\UserBookShowController')
+    ->where(['userId' => '[0-9]+', 'userBookId' => '[0-9]+'])
+    ->name('ogp.user_book');
 Route::get('/{url?}', function () {
     return view('layouts/app');
 })->where('url', '(.*)');


### PR DESCRIPTION
close #614 

# 概要

とりあえず一番みんなが共有する可能性が高いであろうUserBook詳細画面はOGPに対応した。

# 画像(あれば)

<img width="636" alt="スクリーンショット 2020-07-11 22 51 46" src="https://user-images.githubusercontent.com/22770924/87225640-8971c980-c3c9-11ea-8280-cf47770cd572.png">

# 参考

- [localhostのページに対してOGP確認テストを走らせることができるChrome拡張](https://chrome.google.com/webstore/detail/localhost-open-graph-chec/gcbnmkhkglonipggglncobhklaegphgn?hl=ja)
- [TwitterのOGPチェッカー](https://cards-dev.twitter.com/validator)
    - 上のChrome拡張で作成されたURLを入れると良い

